### PR TITLE
Fix composer overflow constraint

### DIFF
--- a/components/composer/Composer.tsx
+++ b/components/composer/Composer.tsx
@@ -38,7 +38,7 @@ export function Composer({
   return (
     <form
       onSubmit={onSubmit}
-      className="composer fixed left-1/2 -translate-x-1/2 bottom-6 z-[5] bg-white rounded-xl border border-border composer-shadow p-4 w-[min(768px,calc(100%-48px))] max-h-[50vh]"
+      className="composer fixed left-1/2 -translate-x-1/2 bottom-6 z-[5] bg-white rounded-xl border border-border composer-shadow p-4 w-[min(768px,calc(100%-48px))] max-h-[50vh] overflow-y-auto flex flex-col"
     >
       <ComposerLabel mode={mode} hasBlockSelected={hasBlockSelected} />
 

--- a/components/composer/PromptInput.tsx
+++ b/components/composer/PromptInput.tsx
@@ -123,7 +123,7 @@ export function PromptInput({
       onKeyDown={handleKeyDown}
       onMouseUp={handleSelectionCapture}
       onKeyUp={handleSelectionCapture}
-      className={`min-h-[48px] px-4 py-3 border border-border rounded-lg bg-white overflow-auto focus:outline-none focus:ring-2 focus:ring-blue-500 text-[0.9375rem] leading-[1.5] ${
+      className={`min-h-[48px] max-h-[300px] px-4 py-3 border border-border rounded-lg bg-white overflow-y-auto focus:outline-none focus:ring-2 focus:ring-blue-500 text-[0.9375rem] leading-[1.5] ${
         disabled ? 'bg-gray-100 cursor-not-allowed' : ''
       }`}
       data-placeholder={finalPlaceholder}

--- a/e2e/tests/composer-overflow.spec.ts
+++ b/e2e/tests/composer-overflow.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect } from '@playwright/test';
+import { LandingPage } from '../page-objects/LandingPage';
+import { ChatPage } from '../page-objects/ChatPage';
+import { ApiMocker, MOCK_RESPONSES } from '../utils/api-mocks';
+
+test.describe('Composer Overflow and Growth', () => {
+  let landingPage: LandingPage;
+  let chatPage: ChatPage;
+  let apiMocker: ApiMocker;
+
+  test.beforeEach(async ({ page }) => {
+    landingPage = new LandingPage(page);
+    chatPage = new ChatPage(page);
+    apiMocker = new ApiMocker(page);
+
+    // Set test mode environment variable
+    await page.addInitScript(() => {
+      (window as any).__TEST_MODE__ = true;
+    });
+
+    await landingPage.goto();
+  });
+
+  test('composer should constrain height to max 50vh and allow scrolling', async ({ page }) => {
+    // Create a thread first
+    await apiMocker.mockChatSuccess(MOCK_RESPONSES.chat.simple);
+    await landingPage.submitFirstPrompt('Hello');
+    await expect(page).toHaveURL(/\/t\/.+/);
+    await chatPage.waitForResponse();
+
+    // Get viewport height
+    const viewportHeight = await page.evaluate(() => window.innerHeight);
+    const maxComposerHeight = viewportHeight * 0.5; // 50vh
+
+    // Type a very long text (multiple lines to trigger overflow)
+    const longText = Array(50)
+      .fill('This is a very long line of text that will make the textarea grow. ')
+      .join('\n');
+
+    await chatPage.typePrompt(longText);
+
+    // Wait for the textarea to update
+    await page.waitForTimeout(100);
+
+    // Get composer height
+    const composerHeight = await chatPage.composer.evaluate((el) => {
+      return el.getBoundingClientRect().height;
+    });
+
+    // Verify composer height doesn't exceed 50vh
+    expect(composerHeight).toBeLessThanOrEqual(maxComposerHeight);
+
+    // Get prompt input height
+    const promptInputHeight = await chatPage.promptInput.evaluate((el) => {
+      return el.getBoundingClientRect().height;
+    });
+
+    // Verify prompt input has a max-height constraint (should be 300px as per our fix)
+    expect(promptInputHeight).toBeLessThanOrEqual(300);
+
+    // Verify prompt input is scrollable
+    const isScrollable = await chatPage.promptInput.evaluate((el) => {
+      return el.scrollHeight > el.clientHeight;
+    });
+
+    expect(isScrollable).toBe(true);
+
+    // Verify we can scroll within the prompt input
+    const initialScrollTop = await chatPage.promptInput.evaluate((el) => el.scrollTop);
+
+    // Scroll to bottom
+    await chatPage.promptInput.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+
+    const scrolledScrollTop = await chatPage.promptInput.evaluate((el) => el.scrollTop);
+
+    // Verify scrollTop changed (meaning scroll happened)
+    expect(scrolledScrollTop).toBeGreaterThan(initialScrollTop);
+  });
+
+  test('composer should grow with content but respect max-height', async ({ page }) => {
+    // Create a thread first
+    await apiMocker.mockChatSuccess(MOCK_RESPONSES.chat.simple);
+    await landingPage.submitFirstPrompt('Hello');
+    await expect(page).toHaveURL(/\/t\/.+/);
+    await chatPage.waitForResponse();
+
+    // Start with short text
+    await chatPage.typePrompt('Short text');
+    await page.waitForTimeout(100);
+
+    const initialHeight = await chatPage.promptInput.evaluate((el) => {
+      return el.getBoundingClientRect().height;
+    });
+
+    // Add more text (enough to trigger growth beyond min-height)
+    const mediumText = Array(10)
+      .fill('This is a line of text. ')
+      .join('\n');
+
+    await chatPage.typePrompt(mediumText);
+    await page.waitForTimeout(100);
+
+    const grownHeight = await chatPage.promptInput.evaluate((el) => {
+      return el.getBoundingClientRect().height;
+    });
+
+    // Verify height increased (should be greater than min-height of 48px)
+    expect(grownHeight).toBeGreaterThan(48);
+
+    // Add A LOT more text to exceed max-height
+    const veryLongText = Array(50)
+      .fill('This is a very long line of text. ')
+      .join('\n');
+
+    await chatPage.typePrompt(veryLongText);
+    await page.waitForTimeout(100);
+
+    const maxedHeight = await chatPage.promptInput.evaluate((el) => {
+      return el.getBoundingClientRect().height;
+    });
+
+    // Verify height is capped at max-height (300px)
+    expect(maxedHeight).toBeLessThanOrEqual(300);
+  });
+
+  test('composer with block controls should not exceed 50vh', async ({ page }) => {
+    // Create a thread first
+    await apiMocker.mockChatSuccess(MOCK_RESPONSES.chat.simple);
+    await landingPage.submitFirstPrompt('Hello');
+    await expect(page).toHaveURL(/\/t\/.+/);
+    await chatPage.waitForResponse();
+
+    // Select a block to show block controls
+    await chatPage.selectBlock(0);
+
+    // Verify block controls are visible
+    const controlsVisible = await chatPage.areBlockControlsVisible();
+    expect(controlsVisible).toBe(true);
+
+    // Type a very long text
+    const longText = Array(50)
+      .fill('This is a very long line of text that will make the textarea grow. ')
+      .join('\n');
+
+    await chatPage.typePrompt(longText);
+    await page.waitForTimeout(100);
+
+    // Get viewport height
+    const viewportHeight = await page.evaluate(() => window.innerHeight);
+    const maxComposerHeight = viewportHeight * 0.5; // 50vh
+
+    // Get composer height (including block controls)
+    const composerHeight = await chatPage.composer.evaluate((el) => {
+      return el.getBoundingClientRect().height;
+    });
+
+    // Verify composer height doesn't exceed 50vh even with block controls
+    expect(composerHeight).toBeLessThanOrEqual(maxComposerHeight);
+
+    // Verify composer is scrollable if needed
+    const isScrollable = await chatPage.composer.evaluate((el) => {
+      return el.scrollHeight > el.clientHeight;
+    });
+
+    // Either the composer fits within bounds or it's scrollable
+    if (composerHeight === maxComposerHeight) {
+      expect(isScrollable).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed composer overflow issue in chat mode when there's too much text in the textarea
- Constrained the PromptInput to max-height of 300px with scrolling
- Ensured the composer never exceeds 50vh (half viewport height)
- Added comprehensive E2E tests to verify the fix

## Changes
1. **Composer.tsx**: Added `overflow-y-auto` and `flex flex-col` to the form to enable proper scrolling when content exceeds max-height
2. **PromptInput.tsx**: Added `max-h-[300px]` and changed `overflow-auto` to `overflow-y-auto` to constrain the textarea height and enable vertical scrolling
3. **composer-overflow.spec.ts**: Added E2E tests to verify:
   - Composer height doesn't exceed 50vh even with very long text
   - PromptInput respects max-height of 300px
   - Scrolling works properly within the textarea
   - Composer with block controls also respects the 50vh limit

## Test Results
All E2E tests pass (9/9 tests across Chrome, Firefox, and Safari):
- ✓ Composer should constrain height to max 50vh and allow scrolling
- ✓ Composer should grow with content but respect max-height
- ✓ Composer with block controls should not exceed 50vh

## Before & After
**Before**: Textarea could grow infinitely, extending beyond the composer container and making it unusable

**After**: Textarea is constrained to 300px max-height, the composer never exceeds 50vh, and users can scroll within the textarea to see all content

🤖 Generated with [Claude Code](https://claude.com/claude-code)