### PR TITLE
fix: maintain bottom spacer when new messages are appended

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -76,7 +76,7 @@
   .thread {
     display: grid;
     gap: 0;
-    padding-bottom: 0px;
+    padding-bottom: calc(50vh + 48px);
   }
 
   .user-message {


### PR DESCRIPTION
## Summary
- Fixed `.thread` element bottom padding to maintain scroll space when new messages are appended
- Changed `padding-bottom` from `0px` to `calc(50vh + 48px)` to account for composer's max height and margins
- Ensures users can always scroll the last message above the fixed composer

## Problem
Previously, the `.thread` element had `padding-bottom: 0px`, which meant there was no permanent bottom spacer. When new messages were appended, users could not scroll the last message above the fixed composer, as the extra scroll room would disappear or reset.

## Solution
Set `.thread` bottom padding to `calc(50vh + 48px)` which accounts for:
- Composer max-height of 50vh (as defined in Composer.tsx:41)
- Composer bottom margin of 24px (`bottom-6`)
- Additional 24px breathing room for comfortable scrolling

This ensures the spacer persists across message additions and provides adequate scroll room.

## Files Changed
- `app/globals.css` - Updated `.thread` padding-bottom (line 79)

## Test plan
- [x] Manual testing: Send multiple messages and verify scroll room persists
- [x] Verify last message can be scrolled above the composer
- [x] Verify spacing works with both short and long composer heights
- [ ] Run existing E2E tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)