### PR TITLE
fix: remove double scrollbar in composer with long text

### DIFF
--- a/components/composer/Composer.tsx
+++ b/components/composer/Composer.tsx
@@ -38,7 +38,7 @@ export function Composer({
   return (
     <form
       onSubmit={onSubmit}
-      className="composer fixed left-1/2 -translate-x-1/2 bottom-6 z-[5] bg-white rounded-xl border border-border composer-shadow p-4 w-[min(768px,calc(100%-48px))] max-h-[50vh] overflow-y-auto flex flex-col"
+      className="composer fixed left-1/2 -translate-x-1/2 bottom-6 z-[5] bg-white rounded-xl border border-border composer-shadow p-4 w-[min(768px,calc(100%-48px))] max-h-[50vh] flex flex-col"
     >
       <ComposerLabel mode={mode} hasBlockSelected={hasBlockSelected} />
 

--- a/e2e/tests/composer-overflow.spec.ts
+++ b/e2e/tests/composer-overflow.spec.ts
@@ -159,14 +159,20 @@ test.describe('Composer Overflow and Growth', () => {
     // Verify composer height doesn't exceed 50vh even with block controls
     expect(composerHeight).toBeLessThanOrEqual(maxComposerHeight);
 
-    // Verify composer is scrollable if needed
-    const isScrollable = await chatPage.composer.evaluate((el) => {
+    // Verify the prompt input (not the composer form) is scrollable
+    const promptInputScrollable = await chatPage.promptInput.evaluate((el) => {
       return el.scrollHeight > el.clientHeight;
     });
 
-    // Either the composer fits within bounds or it's scrollable
-    if (composerHeight === maxComposerHeight) {
-      expect(isScrollable).toBe(true);
-    }
+    // The prompt input should be scrollable when it has lots of text
+    expect(promptInputScrollable).toBe(true);
+
+    // Verify the composer form itself is NOT scrollable (no double scrollbar)
+    const composerScrollable = await chatPage.composer.evaluate((el) => {
+      return el.scrollHeight > el.clientHeight;
+    });
+
+    // The composer form should not be scrollable - only the input should scroll
+    expect(composerScrollable).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Removed `overflow-y-auto` from composer form to eliminate double scrollbar issue
- PromptInput continues to handle text scrolling independently
- Composer maintains 50vh height constraint without showing a scrollbar
- Updated E2E test to verify correct scrolling behavior

## Problem
When the PromptInput had lots of text, **two scrollbars** appeared simultaneously:

1. **PromptInput scrollbar** (expected) - appears at 300px max-height
2. **Composer form scrollbar** (unexpected) - appears when total content slightly exceeds 50vh

This created a confusing UX where:
- Both scrollbars were visible
- The composer form scrollbar had minimal scroll range
- Users had to decide which scrollbar to use

### Root Cause
The composer form in `Composer.tsx:41` had both:
- `max-h-[50vh]` - constrains total height
- `overflow-y-auto` - creates scrollbar when content exceeds constraint

The PromptInput in `PromptInput.tsx:126` also had:
- `max-h-[300px]` - constrains input height
- `overflow-y-auto` - creates scrollbar for long text

When PromptInput reached 300px, the total composer height (label + 300px input + button + hint + padding ≈ 450px) could exceed 50vh on smaller viewports, triggering the composer's scrollbar.

## Solution
Removed `overflow-y-auto` from the composer form (Composer.tsx:41).

**Benefits:**
- ✅ Only one scrollbar (PromptInput) - clearer UX
- ✅ Composer still respects `max-h-[50vh]` constraint
- ✅ PromptInput independently handles text scrolling
- ✅ No confusing nested scrollbars

**Edge Cases Considered:**
- **Block controls visible + long text:** The composer naturally fits within 50vh in most cases (PromptInput max 300px + fixed elements ~190px = ~490px). If viewport is very small (50vh < 490px), content may be clipped, but this is preferable to double scrollbars.
- **Small viewports:** The fix improves UX even on small screens by eliminating scrollbar confusion.

## Files Changed
- `components/composer/Composer.tsx` - Removed `overflow-y-auto` from form className
- `e2e/tests/composer-overflow.spec.ts` - Updated test to verify:
  - PromptInput is scrollable when text is long ✓
  - Composer form is NOT scrollable (no double scrollbar) ✓
  - Composer height stays within 50vh ✓

## Test Plan
- [x] Manual testing: Type long text and verify only PromptInput scrolls
- [x] Manual testing: Verify no double scrollbar appears
- [x] Manual testing: Test with block controls visible
- [x] Updated E2E test to match new behavior
- [ ] Run E2E tests to verify no regressions

## Screenshots
**Before:** Two scrollbars (poor UX)
**After:** One scrollbar on PromptInput only (clear UX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)