### PR TITLE
feat: Add streaming support for chat responses

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import type { ChatRequest, ChatResponse, ApiError } from '@/types/api';
-import { createResponse } from '@/lib/api/openAiClient';
+import { createResponse, createResponseStream } from '@/lib/api/openAiClient';
 import { parseString, validatePrompt } from '@/lib/utils/validation';
 import { getOpenAIModelConfig, DEVELOPER_PROMPT } from '@/lib/config/openai';
 
@@ -10,6 +10,7 @@ export async function POST(request: NextRequest) {
     const body: ChatRequest = await request.json();
     const prompt = parseString(body?.prompt);
     const previousResponseId = body?.previousResponseId;
+    const stream = body?.stream ?? false;
 
     // Validate prompt
     const validation = validatePrompt(prompt);
@@ -23,7 +24,59 @@ export async function POST(request: NextRequest) {
     // Get model configuration
     const modelConfig = getOpenAIModelConfig();
 
-    // Call OpenAI Responses API (enables contextual chat via previous_response_id)
+    // STREAMING PATH: Return Server-Sent Events stream
+    if (stream) {
+      const encoder = new TextEncoder();
+
+      const readable = new ReadableStream({
+        async start(controller) {
+          try {
+            await createResponseStream(
+              {
+                model: modelConfig.model,
+                input: prompt,
+                instructions: DEVELOPER_PROMPT,
+                previousResponseId,
+              },
+              {
+                onToken: (token) => {
+                  const data = JSON.stringify({ type: 'token', content: token });
+                  controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+                },
+                onResponseId: (responseId) => {
+                  const data = JSON.stringify({ type: 'response_id', responseId });
+                  controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+                },
+                onComplete: () => {
+                  const data = JSON.stringify({ type: 'done' });
+                  controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+                  controller.close();
+                },
+                onError: (error) => {
+                  const data = JSON.stringify({ type: 'error', error: error.message });
+                  controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+                  controller.close();
+                },
+              }
+            );
+          } catch (error: any) {
+            const data = JSON.stringify({ type: 'error', error: error.message });
+            controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+            controller.close();
+          }
+        },
+      });
+
+      return new Response(readable, {
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          'Connection': 'keep-alive',
+        },
+      });
+    }
+
+    // NON-STREAMING PATH: Return JSON response
     const result = await createResponse({
       model: modelConfig.model,
       input: prompt,

--- a/components/chat/ChatContainer.tsx
+++ b/components/chat/ChatContainer.tsx
@@ -55,6 +55,8 @@ export function ChatContainer({
   const messages = useStore(useShallow(selectMessagesByThread(threadId)));
   // Get blocks for this specific thread only
   const blocks = useStore(useShallow(selectBlocksByThread(threadId)));
+  // Get streaming message state
+  const streamingMessage = useStore((state) => state.streamingMessage);
 
   // Set active thread and ensure chat mode when component mounts or threadId changes
   useEffect(() => {
@@ -185,6 +187,7 @@ export function ChatContainer({
         selectedBlockId={selectedBlockId}
         isPending={isSubmitting}
         error={error}
+        streamingMessage={streamingMessage}
         onBlockSelect={selectBlock}
         onRemoveSelection={handleRemoveSelection}
         onClearSelections={handleClearSelections}

--- a/components/chat/MessageList.tsx
+++ b/components/chat/MessageList.tsx
@@ -2,11 +2,20 @@
 
 import { useRef, useEffect } from 'react';
 import { Message } from '@/types/message';
-import { Block } from '@/types/block';
+import { Block, BlockData } from '@/types/block';
 import { UserMessage } from './UserMessage';
 import { AssistantMessage } from './AssistantMessage';
 import { PendingMessage } from './PendingMessage';
 import { ErrorMessage } from './ErrorMessage';
+
+/**
+ * Streaming message data for in-progress responses
+ */
+interface StreamingMessageData {
+  messageId: string;
+  threadId: string;
+  blocks: BlockData[];
+}
 
 /**
  * Client Component - Container for all messages in a thread
@@ -19,6 +28,7 @@ interface MessageListProps {
   selectedBlockId?: string | null;
   isPending?: boolean;
   error?: string | null;
+  streamingMessage?: StreamingMessageData | null;
   onBlockSelect?: (blockId: string) => void;
   onRemoveSelection?: (blockId: string, index: number) => void;
   onClearSelections?: (blockId: string) => void;
@@ -32,6 +42,7 @@ export function MessageList({
   selectedBlockId = null,
   isPending = false,
   error = null,
+  streamingMessage = null,
   onBlockSelect,
   onRemoveSelection,
   onClearSelections,
@@ -40,7 +51,7 @@ export function MessageList({
 }: MessageListProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Auto-scroll to bottom on new messages
+  // Auto-scroll to bottom on new messages or streaming updates
   // Skip auto-scroll in block mode (when a block is selected) so user can see the selected block
   useEffect(() => {
     // Don't scroll if in block mode
@@ -55,7 +66,7 @@ export function MessageList({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [messages.length, isPending, error]);
+  }, [messages.length, isPending, error, streamingMessage?.blocks.length]);
 
   // Create block lookup map
   const blockLookup = new Map(blocks.map((block) => [block.id, block]));
@@ -92,7 +103,33 @@ export function MessageList({
         );
       })}
 
-      {isPending && <PendingMessage />}
+      {/* Streaming message (in-progress response) */}
+      {streamingMessage && streamingMessage.blocks.length > 0 && (
+        <AssistantMessage
+          key="streaming"
+          message={{
+            id: streamingMessage.messageId,
+            threadId: streamingMessage.threadId,
+            role: 'assistant',
+            createdAt: Date.now(),
+            content: streamingMessage.blocks.map((_, i) => ({ blockId: `stream-${i}` })),
+            meta: {},
+          }}
+          blocks={streamingMessage.blocks.map((blockData, i) => ({
+            id: `stream-${i}`,
+            messageId: streamingMessage.messageId,
+            type: blockData.type,
+            text: blockData.text,
+            edited: false,
+            selections: [],
+            prevText: null,
+            isRewritten: false,
+          }))}
+          selectedBlockId={null}
+        />
+      )}
+
+      {isPending && !streamingMessage && <PendingMessage />}
       {error && <ErrorMessage error={error} onRetry={onRetry} />}
     </div>
   );

--- a/components/chat/MessageList.tsx
+++ b/components/chat/MessageList.tsx
@@ -51,8 +51,9 @@ export function MessageList({
 }: MessageListProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Auto-scroll to bottom on new messages or streaming updates
+  // Auto-scroll to bottom on new messages
   // Skip auto-scroll in block mode (when a block is selected) so user can see the selected block
+  // Note: Auto-scroll is disabled during streaming to prevent jumping
   useEffect(() => {
     // Don't scroll if in block mode
     if (selectedBlockId) return;
@@ -66,7 +67,7 @@ export function MessageList({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [messages.length, isPending, error, streamingMessage?.blocks.length]);
+  }, [messages.length, isPending, error]);
 
   // Create block lookup map
   const blockLookup = new Map(blocks.map((block) => [block.id, block]));

--- a/hooks/useComposer.ts
+++ b/hooks/useComposer.ts
@@ -187,12 +187,20 @@ export function useComposer(): UseComposerReturn {
               const streamingMessage = finalState.streamingMessage;
 
               if (streamingMessage && streamingMessage.blocks.length > 0) {
-                // Add assistant message with accumulated blocks
-                addAssistantMessage(streamingMessage.blocks, streamResponseIdRef.current);
-              }
+                // Store blocks locally before clearing streaming state
+                // This prevents both streaming and final message from rendering simultaneously
+                const finalBlocks = [...streamingMessage.blocks];
+                const finalResponseId = streamResponseIdRef.current;
 
-              // Clear streaming state
-              clearStream();
+                // Clear streaming state FIRST to prevent double-rendering
+                clearStream();
+
+                // Then add assistant message with accumulated blocks
+                addAssistantMessage(finalBlocks, finalResponseId);
+              } else {
+                // No blocks to add, just clear
+                clearStream();
+              }
 
               // Mark that we have initial response
               setHasInitialResponse(true);

--- a/hooks/useComposer.ts
+++ b/hooks/useComposer.ts
@@ -12,12 +12,13 @@
 
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { useStore, selectSelectedBlock } from '@/lib/store/useStore';
-import { fetchChatCompletion, fetchBlockAction } from '@/lib/api';
-import { splitIntoBlocks, getLastAssistantResponseId } from '@/lib/state';
+import { fetchChatCompletionStream, fetchBlockAction } from '@/lib/api';
+import { getLastAssistantResponseId } from '@/lib/state';
 import { getErrorMessage } from '@/lib/utils/errorHandling';
 import type { BlockAction } from '@/types/api';
+import { idFactory } from '@/lib/utils/idFactory';
 
 export interface UseComposerReturn {
   prompt: string;
@@ -48,6 +49,15 @@ export function useComposer(): UseComposerReturn {
   const setAwaitingResponse = useStore((state) => state.setAwaitingResponse);
   const error = useStore((state) => state.error);
   const setError = useStore((state) => state.setError);
+
+  // Streaming state
+  const startStreaming = useStore((state) => state.startStreaming);
+  const appendStreamToken = useStore((state) => state.appendStreamToken);
+  const setStreamResponseId = useStore((state) => state.setStreamResponseId);
+  const clearStream = useStore((state) => state.clearStream);
+
+  // Track response ID during streaming
+  const streamResponseIdRef = useRef<string | undefined>(undefined);
 
   /**
    * Clear prompt and error
@@ -155,33 +165,61 @@ export function useComposer(): UseComposerReturn {
         // Clear prompt immediately (optimistic)
         setPrompt('');
 
-        // Fetch AI response (use fresh thread ID and previous response ID for context)
-        const response = await fetchChatCompletion(trimmedPrompt, currentThreadId, previousResponseId);
+        // Start streaming state
+        const streamingMessageId = idFactory();
+        startStreaming(streamingMessageId, currentThreadId);
+        streamResponseIdRef.current = undefined;
 
-        // Parse response into blocks
-        const parsedBlocks = splitIntoBlocks(response.text);
+        // Fetch AI response with streaming
+        await fetchChatCompletionStream(
+          trimmedPrompt,
+          {
+            onToken: (token: string) => {
+              appendStreamToken(token);
+            },
+            onResponseId: (responseId: string) => {
+              streamResponseIdRef.current = responseId;
+              setStreamResponseId(responseId);
+            },
+            onComplete: () => {
+              // Get final streaming state and convert to message
+              const finalState = useStore.getState();
+              const streamingMessage = finalState.streamingMessage;
 
-        if (parsedBlocks.length === 0) {
-          throw new Error('No response returned. Please try again.');
-        }
+              if (streamingMessage && streamingMessage.blocks.length > 0) {
+                // Add assistant message with accumulated blocks
+                addAssistantMessage(streamingMessage.blocks, streamResponseIdRef.current);
+              }
 
-        // Add assistant message with response ID for future chaining
-        addAssistantMessage(parsedBlocks, response.responseId);
+              // Clear streaming state
+              clearStream();
 
-        // Mark that we have initial response
-        setHasInitialResponse(true);
+              // Mark that we have initial response
+              setHasInitialResponse(true);
 
-        // Clear any selected block
-        clearSelectedBlock();
+              // Clear any selected block
+              clearSelectedBlock();
 
-        // Clear error on success
-        setError(null);
+              // Clear error on success
+              setError(null);
+
+              // Done submitting
+              setAwaitingResponse(false);
+            },
+            onError: (error: Error) => {
+              clearStream();
+              const errorMessage = getErrorMessage(error, 'We hit a snag getting that response. Try again.');
+              setError(errorMessage);
+              setAwaitingResponse(false);
+            },
+          },
+          currentThreadId,
+          previousResponseId
+        );
       } catch (err) {
+        clearStream();
         const errorMessage = getErrorMessage(err, 'We hit a snag getting that response. Try again.');
         setError(errorMessage);
-        // Restore prompt on error (allow retry)
-        // Note: prompt is already cleared optimistically, user can use up arrow or retype
-      } finally {
         setAwaitingResponse(false);
       }
     },
@@ -201,6 +239,10 @@ export function useComposer(): UseComposerReturn {
       setHasInitialResponse,
       updateThreadTitle,
       setAwaitingResponse,
+      startStreaming,
+      appendStreamToken,
+      setStreamResponseId,
+      clearStream,
     ]
   );
 

--- a/lib/api/chat.ts
+++ b/lib/api/chat.ts
@@ -38,3 +38,126 @@ export async function fetchChatCompletion(
     body: JSON.stringify(requestBody),
   });
 }
+
+/**
+ * Callbacks for streaming chat completion
+ */
+export interface StreamChatCallbacks {
+  onToken: (token: string) => void;
+  onResponseId: (responseId: string) => void;
+  onComplete: () => void;
+  onError: (error: Error) => void;
+}
+
+/**
+ * Fetch chat completion with streaming from OpenAI
+ * Response tokens are delivered via callbacks as they arrive
+ *
+ * @param prompt - User prompt text
+ * @param callbacks - Event handlers for stream events
+ * @param threadId - Optional thread ID for context
+ * @param previousResponseId - Optional response ID for contextual chaining
+ */
+export async function fetchChatCompletionStream(
+  prompt: string,
+  callbacks: StreamChatCallbacks,
+  threadId?: string,
+  previousResponseId?: string
+): Promise<void> {
+  // Validate prompt
+  const trimmedPrompt = prompt.trim();
+  const validation = validatePrompt(trimmedPrompt);
+
+  if (!validation.valid) {
+    throw new Error(validation.error || 'Invalid prompt');
+  }
+
+  // Build request with streaming enabled
+  const requestBody: ChatRequest = {
+    prompt: trimmedPrompt,
+    threadId,
+    mode: 'chat',
+    previousResponseId,
+    stream: true,
+  };
+
+  try {
+    const response = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(requestBody),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({ error: 'Request failed' }));
+      throw new Error(errorData.error || 'Request failed');
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error('No response body available');
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+
+        if (done) {
+          // Process remaining buffer
+          if (buffer.trim()) {
+            processStreamBuffer(buffer, callbacks);
+          }
+          break;
+        }
+
+        buffer += decoder.decode(value, { stream: true });
+
+        // Split on double newline (SSE separator)
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop() || '';
+
+        for (const part of parts) {
+          processStreamBuffer(part, callbacks);
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  } catch (error) {
+    callbacks.onError(error as Error);
+  }
+}
+
+/**
+ * Process SSE buffer and dispatch to callbacks
+ */
+function processStreamBuffer(data: string, callbacks: StreamChatCallbacks): void {
+  const lines = data.split('\n');
+
+  for (const line of lines) {
+    if (!line.startsWith('data: ')) continue;
+
+    const jsonStr = line.slice(6);
+    if (!jsonStr.trim()) continue;
+
+    try {
+      const event = JSON.parse(jsonStr);
+
+      if (event.type === 'token' && event.content !== undefined) {
+        callbacks.onToken(event.content);
+      } else if (event.type === 'response_id' && event.responseId) {
+        callbacks.onResponseId(event.responseId);
+      } else if (event.type === 'done') {
+        callbacks.onComplete();
+      } else if (event.type === 'error') {
+        callbacks.onError(new Error(event.error || 'Stream error'));
+      }
+    } catch (e) {
+      // Skip malformed JSON
+      console.warn('Failed to parse stream event:', jsonStr);
+    }
+  }
+}

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -5,6 +5,7 @@
  */
 
 export { apiFetch, ApiClientError } from './client';
-export { fetchChatCompletion } from './chat';
+export { fetchChatCompletion, fetchChatCompletionStream } from './chat';
+export type { StreamChatCallbacks } from './chat';
 export { fetchBlockAction } from './blockAction';
 export { fetchConfig, clearConfigCache } from './config';

--- a/lib/api/openAiClient.ts
+++ b/lib/api/openAiClient.ts
@@ -70,3 +70,57 @@ export const createResponse = async (params: CreateResponseParams): Promise<Resp
     responseId: response.id,
   };
 };
+
+/**
+ * Event handler interface for streaming responses
+ */
+export interface StreamEventHandler {
+  onToken: (token: string) => void;
+  onResponseId: (responseId: string) => void;
+  onComplete: () => void;
+  onError: (error: Error) => void;
+}
+
+/**
+ * Create a streaming response using OpenAI's Responses API
+ * This enables real-time token-by-token output
+ *
+ * @param params - Response parameters
+ * @param handler - Event handlers for stream events
+ */
+export const createResponseStream = async (
+  params: CreateResponseParams,
+  handler: StreamEventHandler
+): Promise<void> => {
+  const client = getOpenAiClient();
+
+  try {
+    const stream = await client.responses.create({
+      model: params.model,
+      input: params.input,
+      instructions: params.instructions,
+      store: true,
+      stream: true,
+      ...(params.previousResponseId && { previous_response_id: params.previousResponseId }),
+    });
+
+    for await (const event of stream) {
+      // Handle response creation event (contains response ID)
+      if (event.type === 'response.created') {
+        handler.onResponseId(event.response.id);
+      }
+      // Handle text delta events (streaming tokens)
+      else if (event.type === 'response.output_text.delta') {
+        if (event.delta) {
+          handler.onToken(event.delta);
+        }
+      }
+      // Handle completion
+      else if (event.type === 'response.completed') {
+        handler.onComplete();
+      }
+    }
+  } catch (error) {
+    handler.onError(error as Error);
+  }
+};

--- a/lib/api/streaming.ts
+++ b/lib/api/streaming.ts
@@ -1,0 +1,94 @@
+/**
+ * Server-Sent Events (SSE) stream parsing utilities
+ */
+
+export interface StreamEvent {
+  type: 'token' | 'done' | 'error';
+  content?: string;
+  responseId?: string;
+  error?: string;
+}
+
+export interface StreamCallbacks {
+  onToken: (token: string) => void;
+  onComplete: (responseId?: string) => void;
+  onError: (error: Error) => void;
+}
+
+/**
+ * Parse and consume a Server-Sent Events stream from a fetch response
+ *
+ * @param response - Fetch response with SSE body
+ * @param callbacks - Event handlers for tokens, completion, and errors
+ */
+export async function consumeSSEStream(
+  response: Response,
+  callbacks: StreamCallbacks
+): Promise<void> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    throw new Error('No response body available for streaming');
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+
+      if (done) {
+        // Process any remaining data in buffer
+        if (buffer.trim()) {
+          processSSELines(buffer, callbacks);
+        }
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+
+      // Split on double newline (SSE event separator)
+      const parts = buffer.split('\n\n');
+      // Keep the last incomplete part in buffer
+      buffer = parts.pop() || '';
+
+      // Process complete events
+      for (const part of parts) {
+        processSSELines(part, callbacks);
+      }
+    }
+  } catch (error) {
+    callbacks.onError(error as Error);
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/**
+ * Process SSE lines and dispatch to appropriate callback
+ */
+function processSSELines(data: string, callbacks: StreamCallbacks): void {
+  const lines = data.split('\n');
+
+  for (const line of lines) {
+    if (!line.startsWith('data: ')) continue;
+
+    const jsonStr = line.slice(6); // Remove 'data: ' prefix
+    if (!jsonStr.trim()) continue;
+
+    try {
+      const event: StreamEvent = JSON.parse(jsonStr);
+
+      if (event.type === 'token' && event.content !== undefined) {
+        callbacks.onToken(event.content);
+      } else if (event.type === 'done') {
+        callbacks.onComplete(event.responseId);
+      } else if (event.type === 'error') {
+        callbacks.onError(new Error(event.error || 'Stream error'));
+      }
+    } catch (e) {
+      // Skip malformed JSON lines
+      console.warn('Failed to parse SSE event:', jsonStr);
+    }
+  }
+}

--- a/lib/store/slices/streamingSlice.ts
+++ b/lib/store/slices/streamingSlice.ts
@@ -1,0 +1,74 @@
+/**
+ * Streaming slice - Manages streaming message state
+ */
+
+import { StateCreator } from 'zustand';
+import { splitIntoBlocks } from '@/lib/state/parser';
+import { BlockData } from '@/types/block';
+import { AppState } from '@/types/state';
+
+export interface StreamingMessage {
+  messageId: string;
+  threadId: string;
+  accumulatedText: string;
+  blocks: BlockData[];
+  responseId?: string;
+}
+
+export interface StreamingSlice {
+  streamingMessage: StreamingMessage | null;
+
+  startStreaming: (messageId: string, threadId: string) => void;
+  appendStreamToken: (token: string) => void;
+  setStreamResponseId: (responseId: string) => void;
+  clearStream: () => void;
+}
+
+export const streamingSlice: StateCreator<
+  AppState & StreamingSlice,
+  [],
+  [],
+  StreamingSlice
+> = (set, get) => ({
+  streamingMessage: null,
+
+  startStreaming: (messageId, threadId) => {
+    set({
+      streamingMessage: {
+        messageId,
+        threadId,
+        accumulatedText: '',
+        blocks: [],
+        responseId: undefined,
+      },
+    });
+  },
+
+  appendStreamToken: (token) => {
+    const current = get().streamingMessage;
+    if (!current) return;
+
+    const newText = current.accumulatedText + token;
+    set({
+      streamingMessage: {
+        ...current,
+        accumulatedText: newText,
+        blocks: splitIntoBlocks(newText),
+      },
+    });
+  },
+
+  setStreamResponseId: (responseId) => {
+    const current = get().streamingMessage;
+    if (!current) return;
+
+    set({
+      streamingMessage: {
+        ...current,
+        responseId,
+      },
+    });
+  },
+
+  clearStream: () => set({ streamingMessage: null }),
+});

--- a/lib/store/useStore.ts
+++ b/lib/store/useStore.ts
@@ -8,13 +8,14 @@ import { devtools, persist } from 'zustand/middleware';
 import { threadSlice, ThreadSlice } from './slices/threadSlice';
 import { blockSlice, BlockSlice } from './slices/blockSlice';
 import { uiSlice, UISlice } from './slices/uiSlice';
+import { streamingSlice, StreamingSlice } from './slices/streamingSlice';
 import { AppState } from '@/types/state';
 import { Block } from '@/types/block';
 import { Thread } from '@/types/thread';
 import { Message } from '@/types/message';
 import { isTestMode } from '@/lib/utils/testMode';
 
-export type StoreState = AppState & ThreadSlice & BlockSlice & UISlice;
+export type StoreState = AppState & ThreadSlice & BlockSlice & UISlice & StreamingSlice;
 
 /**
  * Main store hook
@@ -30,6 +31,7 @@ export const useStore = create<StoreState>()(
             ...threadSlice(...args),
             ...blockSlice(...args),
             ...uiSlice(...args),
+            ...streamingSlice(...args),
           }),
           {
             name: 'coo-test-storage',
@@ -45,6 +47,7 @@ export const useStore = create<StoreState>()(
           ...threadSlice(...args),
           ...blockSlice(...args),
           ...uiSlice(...args),
+          ...streamingSlice(...args),
         }),
     {
       name: 'coo-store',

--- a/types/api.ts
+++ b/types/api.ts
@@ -4,6 +4,7 @@ export interface ChatRequest {
   threadId?: string;
   mode?: 'chat';
   previousResponseId?: string;
+  stream?: boolean;
 }
 
 export interface ChatResponse {


### PR DESCRIPTION
## Summary
- Implements real-time token-by-token streaming for chat responses
- Response text appears word-by-word as tokens arrive from OpenAI
- Uses Server-Sent Events (SSE) for efficient streaming
- Block transformations remain non-streaming (standalone operations)

## Changes

### New Files
- `lib/store/slices/streamingSlice.ts` - Zustand slice for streaming state
- `lib/api/streaming.ts` - SSE stream parser utilities

### Modified Files
- `lib/api/openAiClient.ts` - Added `createResponseStream()` for streaming
- `app/api/chat/route.ts` - Returns SSE stream when `stream: true`
- `lib/api/chat.ts` - Added `fetchChatCompletionStream()` with callbacks
- `hooks/useComposer.ts` - Uses streaming by default
- `components/chat/MessageList.tsx` - Renders streaming messages
- `components/chat/ChatContainer.tsx` - Passes streaming state to MessageList
- `types/api.ts` - Added `stream?: boolean` to ChatRequest

## How It Works
1. User submits message → `startStreaming()` initializes streaming state
2. API returns SSE stream with tokens
3. Each token triggers `appendStreamToken()` → re-parses blocks → UI updates
4. On completion, streaming state converts to final message with persistence

## Test plan
- [x] TypeScript type checking passes
- [x] All 272 tests pass
- [ ] Manual testing: verify streaming displays tokens incrementally
- [ ] Verify block transformations still work (non-streaming)
- [ ] Test error handling during streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)