### PR TITLE
feat: Disable send button during submission for visual feedback

### DIFF
--- a/hooks/useComposer.ts
+++ b/hooks/useComposer.ts
@@ -87,6 +87,7 @@ export function useComposer(): UseComposerReturn {
       }
 
       setError(null);
+      setAwaitingResponse(true);
 
       try {
         const result = await fetchBlockAction(
@@ -104,9 +105,11 @@ export function useComposer(): UseComposerReturn {
         const errorMessage = getErrorMessage(err, 'Failed to transform block');
         setError(errorMessage);
         // Don't clear prompt on error (allow retry)
+      } finally {
+        setAwaitingResponse(false);
       }
     },
-    [selectedBlock, prompt]
+    [selectedBlock, prompt, setAwaitingResponse]
   );
 
   /**


### PR DESCRIPTION
## Summary
- Adds `setAwaitingResponse(true/false)` calls to `handleBlockAction` in useComposer hook
- The send button now disables when block actions (Translate, ELI5, Example, Expand, Ask) are in progress
- Provides users visual feedback that their action has been registered

## Changes
This is a minimal 4-line change that leverages the existing state management:
- Set `isAwaitingResponse` to `true` before the API call
- Set `isAwaitingResponse` to `false` in a `finally` block (handles both success and error)
- Added `setAwaitingResponse` to the dependency array

The send button was already disabled during chat mode submissions. This change extends that behavior to block actions for consistency.

## Test plan
- [x] All 272 unit tests pass
- [ ] Manual test: Select a block, click "Translate" → Send button should disable
- [ ] Manual test: Send button re-enables after response completes
- [ ] Manual test: Send button re-enables on error (e.g., network failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)