### PR TITLE
feat: split list items into separate selectable blocks

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -405,6 +405,12 @@
     font-weight: 600;
   }
 
+  /* Reduce gap between consecutive list blocks (sibling items from same logical list) */
+  /* Don't reduce gap when preceding block is selected (has chips/buttons visible) */
+  .doc-block:has(> .doc-content > .doc-list):not(.is-selected) + .doc-block:has(> .doc-content > .doc-list) {
+    margin-top: -12px;
+  }
+
   .doc-code {
     margin: 0;
     padding: 12px 16px;

--- a/lib/state/parser.ts
+++ b/lib/state/parser.ts
@@ -91,6 +91,16 @@ export const getCommandOutput = ({
 
 const isListLine = (line: string): boolean => /^(\s*)([-*+]|\d+\.)\s+/.test(line);
 
+/**
+ * Get the indent level of a list line (number of leading spaces)
+ * Returns null if not a list line
+ */
+const getListIndent = (line: string): number | null => {
+  const match = line.match(/^(\s*)([-*+]|\d+\.)\s+/);
+  if (!match) return null;
+  return match[1].length;
+};
+
 const normalizeBlocks = (blocks: BlockData[]): BlockData[] => {
   const result: BlockData[] = [];
 
@@ -221,11 +231,21 @@ export const splitIntoBlocks = (content: string): BlockData[] => {
     }
 
     if (listLine) {
+      const indent = getListIndent(line);
+
       if (currentMode !== 'list') {
+        // Starting a new list section
         flushParagraph();
         currentMode = 'list';
+        buffer.push(line);
+      } else if (indent === 0 && buffer.length > 0) {
+        // New top-level item - flush current buffer as block, start new one
+        flushList();
+        buffer.push(line);
+      } else {
+        // Nested item or continuation - add to current buffer
+        buffer.push(line);
       }
-      buffer.push(line);
       return;
     }
 

--- a/tests/lib/state/index.test.ts
+++ b/tests/lib/state/index.test.ts
@@ -453,20 +453,26 @@ describe('splitIntoBlocks', () => {
     expect(blocks[0].text).toContain('const x = 1');
   });
 
-  it('should detect list blocks', () => {
+  it('should split top-level list items into separate blocks', () => {
     const text = '- Item 1\n- Item 2\n- Item 3';
     const blocks = splitIntoBlocks(text);
-    expect(blocks).toHaveLength(1);
+    expect(blocks).toHaveLength(3);
     expect(blocks[0].type).toBe('list');
+    expect(blocks[0].text).toBe('- Item 1');
+    expect(blocks[1].text).toBe('- Item 2');
+    expect(blocks[2].text).toBe('- Item 3');
   });
 
   it('should handle mixed content types', () => {
     const text = 'Intro paragraph\n\n- List item 1\n- List item 2\n\nConclusion';
     const blocks = splitIntoBlocks(text);
-    expect(blocks).toHaveLength(3);
+    expect(blocks).toHaveLength(4);
     expect(blocks[0].type).toBe('paragraph');
     expect(blocks[1].type).toBe('list');
-    expect(blocks[2].type).toBe('paragraph');
+    expect(blocks[1].text).toBe('- List item 1');
+    expect(blocks[2].type).toBe('list');
+    expect(blocks[2].text).toBe('- List item 2');
+    expect(blocks[3].type).toBe('paragraph');
   });
 
   it('should handle code blocks with language specifier', () => {
@@ -485,11 +491,21 @@ describe('splitIntoBlocks', () => {
     expect(blocks[2].type).toBe('code');
   });
 
-  it('should handle list with numbered items', () => {
+  it('should split numbered list items into separate blocks', () => {
     const text = '1. First\n2. Second\n3. Third';
     const blocks = splitIntoBlocks(text);
-    expect(blocks).toHaveLength(1);
+    expect(blocks).toHaveLength(3);
     expect(blocks[0].type).toBe('list');
+    expect(blocks[0].text).toBe('1. First');
+  });
+
+  it('should keep nested list items with their parent block', () => {
+    const text = '- Python\n  - Django\n  - Flask\n- JavaScript\n- Rust';
+    const blocks = splitIntoBlocks(text);
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0].text).toBe('- Python\n  - Django\n  - Flask');
+    expect(blocks[1].text).toBe('- JavaScript');
+    expect(blocks[2].text).toBe('- Rust');
   });
 
   it('should trim whitespace from blocks', () => {


### PR DESCRIPTION
Each top-level list item now becomes its own block with its own gutter, enabling individual item selection. Nested items stay with their parent.

- Add getListIndent() helper to detect indent level
- Modify splitIntoBlocks() to flush on each indent=0 list item
- Add CSS to reduce gap between consecutive list blocks
- Preserve normal spacing when preceding block is selected (has chips)