### PR TITLE
feat: add AI-generated thread titles

### DIFF
--- a/app/api/thread-title/route.ts
+++ b/app/api/thread-title/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import OpenAI from 'openai';
+import type { TitleRequest, TitleResponse, ApiError } from '@/types/api';
+
+const client = new OpenAI();
+
+export async function POST(request: NextRequest) {
+  try {
+    const body: TitleRequest = await request.json();
+
+    if (!body.prompt?.trim()) {
+      return NextResponse.json<ApiError>(
+        { error: 'Prompt is required' },
+        { status: 400 }
+      );
+    }
+
+    const systemPrompt = `Generate a concise title (5-7 words max) for a conversation thread.
+The title should be descriptive and capture the main topic.
+Return ONLY the title, no quotes or extra formatting.`;
+
+    const userContent = body.response
+      ? `User's question: ${body.prompt}\n\nAI's response: ${body.response}`
+      : `User's question: ${body.prompt}`;
+
+    const completion = await client.chat.completions.create({
+      model: 'gpt-5-mini',
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userContent },
+      ],
+      max_tokens: 30,
+      temperature: 0.7,
+    });
+
+    const generatedTitle = completion.choices[0]?.message?.content?.trim();
+
+    // Fallback to truncated prompt if generation fails
+    const title = generatedTitle || (
+      body.prompt.length > 50
+        ? body.prompt.substring(0, 50) + '...'
+        : body.prompt
+    );
+
+    return NextResponse.json<TitleResponse>({ title });
+  } catch (error: unknown) {
+    console.error('Thread title API error:', error);
+
+    return NextResponse.json<ApiError>(
+      { error: 'Failed to generate thread title' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/thread-title/route.ts
+++ b/app/api/thread-title/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import OpenAI from 'openai';
 import type { TitleRequest, TitleResponse, ApiError } from '@/types/api';
+import { getOpenAiClient } from '@/lib/api/openAiClient';
 
-const client = new OpenAI();
+const TITLE_INSTRUCTIONS = `Generate a concise title (5-7 words max) for a conversation thread.
+The title should be descriptive and capture the main topic.
+Return ONLY the title, no quotes or extra formatting.`;
 
 export async function POST(request: NextRequest) {
   try {
@@ -15,25 +17,20 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const systemPrompt = `Generate a concise title (5-7 words max) for a conversation thread.
-The title should be descriptive and capture the main topic.
-Return ONLY the title, no quotes or extra formatting.`;
+    const client = getOpenAiClient();
 
-    const userContent = body.response
+    const inputContent = body.response
       ? `User's question: ${body.prompt}\n\nAI's response: ${body.response}`
       : `User's question: ${body.prompt}`;
 
-    const completion = await client.chat.completions.create({
+    // Use the Responses API (consistent with the rest of the codebase)
+    const response = await client.responses.create({
       model: 'gpt-5-mini',
-      messages: [
-        { role: 'system', content: systemPrompt },
-        { role: 'user', content: userContent },
-      ],
-      max_tokens: 30,
-      temperature: 0.7,
+      input: inputContent,
+      instructions: TITLE_INSTRUCTIONS,
     });
 
-    const generatedTitle = completion.choices[0]?.message?.content?.trim();
+    const generatedTitle = response.output_text?.trim();
 
     // Fallback to truncated prompt if generation fails
     const title = generatedTitle || (
@@ -44,10 +41,11 @@ Return ONLY the title, no quotes or extra formatting.`;
 
     return NextResponse.json<TitleResponse>({ title });
   } catch (error: unknown) {
-    console.error('Thread title API error:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error('Thread title API error:', errorMessage, error);
 
     return NextResponse.json<ApiError>(
-      { error: 'Failed to generate thread title' },
+      { error: 'Failed to generate thread title', details: errorMessage },
       { status: 500 }
     );
   }

--- a/components/sidebar/SidebarThreadList.tsx
+++ b/components/sidebar/SidebarThreadList.tsx
@@ -49,7 +49,10 @@ export function SidebarThreadList({ threads: serverThreads }: SidebarThreadListP
 
   // Use server threads for SSR/initial render, then switch to store threads after mount
   // This prevents hydration mismatch while keeping reactivity for title updates
-  const threads = hasMounted ? storeThreads : serverThreads;
+  // Filter out empty threads (the default "Main" thread created by store initialization)
+  // to avoid showing placeholder threads when database is empty
+  const rawThreads = hasMounted ? storeThreads : serverThreads;
+  const threads = rawThreads.filter((thread) => thread.messages.length > 0);
 
   const handleClick = () => {
     // On mobile, close the sidebar when navigating

--- a/components/sidebar/SidebarThreadList.tsx
+++ b/components/sidebar/SidebarThreadList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { MessageSquare } from 'lucide-react';
@@ -23,10 +23,18 @@ export function SidebarThreadList({ threads: serverThreads }: SidebarThreadListP
   const { setOpen, isMobile, state } = useSidebar();
   const isCollapsed = state === 'collapsed';
 
+  // Track hydration state to avoid mismatch
+  const [hasMounted, setHasMounted] = useState(false);
+
   // Subscribe to store threads for reactivity (title updates, new threads)
   const storeThreads = useStore((state) => state.threads);
   const mergeThreadFromSupabase = useStore((state) => state.mergeThreadFromSupabase);
   const hasSynced = useRef(false);
+
+  // Mark as mounted after hydration
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
 
   // Sync server threads to store on mount (once)
   useEffect(() => {
@@ -39,8 +47,9 @@ export function SidebarThreadList({ threads: serverThreads }: SidebarThreadListP
     });
   }, [serverThreads, mergeThreadFromSupabase]);
 
-  // Use store threads (reactive) for display
-  const threads = storeThreads;
+  // Use server threads for SSR/initial render, then switch to store threads after mount
+  // This prevents hydration mismatch while keeping reactivity for title updates
+  const threads = hasMounted ? storeThreads : serverThreads;
 
   const handleClick = () => {
     // On mobile, close the sidebar when navigating

--- a/components/sidebar/SidebarThreadList.tsx
+++ b/components/sidebar/SidebarThreadList.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { MessageSquare } from 'lucide-react';
@@ -9,17 +10,37 @@ import {
   SidebarMenuButton,
   useSidebar,
 } from '@/components/ui/sidebar';
+import { useStore } from '@/lib/store/useStore';
 import type { Thread } from '@/types/thread';
 
 interface SidebarThreadListProps {
   threads: Thread[];
 }
 
-export function SidebarThreadList({ threads }: SidebarThreadListProps) {
+export function SidebarThreadList({ threads: serverThreads }: SidebarThreadListProps) {
   const params = useParams();
   const currentThreadId = params?.threadId as string | undefined;
   const { setOpen, isMobile, state } = useSidebar();
   const isCollapsed = state === 'collapsed';
+
+  // Subscribe to store threads for reactivity (title updates, new threads)
+  const storeThreads = useStore((state) => state.threads);
+  const mergeThreadFromSupabase = useStore((state) => state.mergeThreadFromSupabase);
+  const hasSynced = useRef(false);
+
+  // Sync server threads to store on mount (once)
+  useEffect(() => {
+    if (hasSynced.current || serverThreads.length === 0) return;
+    hasSynced.current = true;
+
+    // Merge server threads into the store (preserves any local changes)
+    serverThreads.forEach((thread) => {
+      mergeThreadFromSupabase(thread, thread.messages, []);
+    });
+  }, [serverThreads, mergeThreadFromSupabase]);
+
+  // Use store threads (reactive) for display
+  const threads = storeThreads;
 
   const handleClick = () => {
     // On mobile, close the sidebar when navigating

--- a/hooks/useComposer.ts
+++ b/hooks/useComposer.ts
@@ -14,7 +14,7 @@
 
 import { useState, useCallback, useRef } from 'react';
 import { useStore, selectSelectedBlock } from '@/lib/store/useStore';
-import { fetchChatCompletionStream, fetchBlockAction } from '@/lib/api';
+import { fetchChatCompletionStream, fetchBlockAction, generateThreadTitle } from '@/lib/api';
 import { getLastAssistantResponseId } from '@/lib/state';
 import { getErrorMessage } from '@/lib/utils/errorHandling';
 import type { BlockAction } from '@/types/api';
@@ -155,14 +155,6 @@ export function useComposer(): UseComposerReturn {
         // IMPORTANT: Get fresh activeThreadId from store (after potential createThread())
         const currentThreadId = useStore.getState().activeThreadId;
 
-        // Update thread title ONLY for the first message (when creating new thread)
-        if (isNewThread) {
-          const threadTitle = trimmedPrompt.length > 50
-            ? trimmedPrompt.substring(0, 50) + '...'
-            : trimmedPrompt;
-          updateThreadTitle(currentThreadId, threadTitle);
-        }
-
         // Get previous response ID for contextual chat (chains conversation)
         const currentState = useStore.getState();
         const previousResponseId = getLastAssistantResponseId(currentState, currentThreadId);
@@ -194,6 +186,9 @@ export function useComposer(): UseComposerReturn {
               const finalState = useStore.getState();
               const streamingMessage = finalState.streamingMessage;
 
+              // Capture accumulated text for title generation before clearing
+              const accumulatedText = streamingMessage?.accumulatedText || '';
+
               if (streamingMessage && streamingMessage.blocks.length > 0) {
                 // Store blocks locally before clearing streaming state
                 // This prevents both streaming and final message from rendering simultaneously
@@ -221,6 +216,22 @@ export function useComposer(): UseComposerReturn {
 
               // Done submitting
               setAwaitingResponse(false);
+
+              // Generate AI title for new threads (fire-and-forget, non-blocking)
+              if (isNewThread) {
+                generateThreadTitle(trimmedPrompt, accumulatedText)
+                  .then((title) => {
+                    updateThreadTitle(currentThreadId, title);
+                  })
+                  .catch((err) => {
+                    console.error('Failed to generate thread title:', err);
+                    // Fallback: use truncated prompt
+                    const fallbackTitle = trimmedPrompt.length > 50
+                      ? trimmedPrompt.substring(0, 50) + '...'
+                      : trimmedPrompt;
+                    updateThreadTitle(currentThreadId, fallbackTitle);
+                  });
+              }
             },
             onError: (error: Error) => {
               clearStream();

--- a/lib/api/chat.ts
+++ b/lib/api/chat.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from './client';
-import type { ChatRequest, ChatResponse } from '@/types/api';
+import type { ChatRequest, ChatResponse, TitleRequest, TitleResponse } from '@/types/api';
 import type { Settings } from '@/types/settings';
 import { validatePrompt } from '@/lib/utils/validation';
 
@@ -194,4 +194,32 @@ function processStreamBuffer(
   }
 
   return { hadParseError };
+}
+
+/**
+ * Generate a succinct title for a thread using AI
+ *
+ * @param prompt - User's first message in the thread
+ * @param response - Optional AI response for better context
+ * @returns Promise with generated title
+ * @throws Error on API failure
+ */
+export async function generateThreadTitle(
+  prompt: string,
+  response?: string
+): Promise<string> {
+  const requestBody: TitleRequest = { prompt, response };
+
+  const res = await fetch('/api/thread-title', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(requestBody),
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to generate thread title');
+  }
+
+  const data: TitleResponse = await res.json();
+  return data.title;
 }

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -5,7 +5,7 @@
  */
 
 export { apiFetch, ApiClientError } from './client';
-export { fetchChatCompletion, fetchChatCompletionStream } from './chat';
+export { fetchChatCompletion, fetchChatCompletionStream, generateThreadTitle } from './chat';
 export type { StreamChatCallbacks } from './chat';
 export { fetchBlockAction } from './blockAction';
 export { fetchConfig, clearConfigCache } from './config';

--- a/types/api.ts
+++ b/types/api.ts
@@ -36,6 +36,16 @@ export interface ConfigResponse {
   supabaseAnonKey: string;
 }
 
+// Thread Title API Types
+export interface TitleRequest {
+  prompt: string;
+  response?: string;
+}
+
+export interface TitleResponse {
+  title: string;
+}
+
 // Error Response
 export interface ApiError {
   error: string;


### PR DESCRIPTION
## Summary
- Adds a new `/api/thread-title` endpoint that uses `gpt-5-mini` to generate succinct, descriptive thread titles
- After the first AI response completes in a new thread, automatically calls this endpoint to generate a title
- Thread title stays as "Main" until the API returns, then updates to the AI-generated title
- Falls back to truncated prompt (first 50 chars) if the API call fails

## Changes
- **app/api/thread-title/route.ts** - New API route for AI title generation
- **types/api.ts** - Added `TitleRequest` and `TitleResponse` interfaces
- **lib/api/chat.ts** - Added `generateThreadTitle()` client function
- **lib/api/index.ts** - Export the new function
- **hooks/useComposer.ts** - Integrate title generation in `onComplete` callback (fire-and-forget)

## Test plan
- [ ] Create a new thread and send a message
- [ ] Verify title stays as "Main" during streaming
- [ ] Verify title updates to AI-generated title after response completes
- [ ] Test API failure scenario (title should fall back to truncated prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)