### PR TITLE
add response language setting for i18n support

### DIFF
--- a/app/api/block-action/route.ts
+++ b/app/api/block-action/route.ts
@@ -3,7 +3,7 @@ import type { BlockActionRequest, BlockActionResponse, ApiError, BlockAction } f
 import type { TranslateLanguage } from '@/types/settings';
 import { getOpenAiClient } from '@/lib/api/openAiClient';
 import { parseString, validatePrompt } from '@/lib/utils/validation';
-import { getOpenAIModelConfig, BLOCK_ACTION_PROMPT } from '@/lib/config/openai';
+import { getOpenAIModelConfig, getBlockActionPrompt } from '@/lib/config/openai';
 import { handleApiError } from '@/lib/api/errorHandler';
 
 // Build action-specific prompt based on action type
@@ -100,7 +100,7 @@ export async function POST(request: NextRequest) {
     const completion = await openai.chat.completions.create({
       model: settings?.model || modelConfig.model,
       messages: [
-        { role: 'system', content: BLOCK_ACTION_PROMPT },
+        { role: 'system', content: getBlockActionPrompt(settings?.responseLanguage) },
         { role: 'user', content: actionPrompt },
       ],
     });

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import type { ChatRequest, ChatResponse, ApiError } from '@/types/api';
 import { createResponse, createResponseStream } from '@/lib/api/openAiClient';
 import { parseString, validatePrompt } from '@/lib/utils/validation';
-import { getOpenAIModelConfig, DEVELOPER_PROMPT } from '@/lib/config/openai';
+import { getOpenAIModelConfig, getDeveloperPrompt } from '@/lib/config/openai';
 import { handleApiError } from '@/lib/api/errorHandler';
 
 export async function POST(request: NextRequest) {
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
               {
                 model: settings?.model || modelConfig.model,
                 input: prompt,
-                instructions: DEVELOPER_PROMPT,
+                instructions: getDeveloperPrompt(settings?.responseLanguage),
                 previousResponseId,
                 reasoningEffort: settings?.reasoningEffort,
                 webSearchEnabled: settings?.webSearchEnabled,
@@ -84,7 +84,7 @@ export async function POST(request: NextRequest) {
     const result = await createResponse({
       model: settings?.model || modelConfig.model,
       input: prompt,
-      instructions: DEVELOPER_PROMPT,
+      instructions: getDeveloperPrompt(settings?.responseLanguage),
       previousResponseId,
       reasoningEffort: settings?.reasoningEffort,
       webSearchEnabled: settings?.webSearchEnabled,

--- a/components/settings/SettingsForm.tsx
+++ b/components/settings/SettingsForm.tsx
@@ -6,7 +6,7 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { useStore } from '@/lib/store/useStore';
-import type { ModelType, ReasoningEffort, TranslateLanguage } from '@/types/settings';
+import type { ModelType, ReasoningEffort, ResponseLanguage, TranslateLanguage } from '@/types/settings';
 
 const MODEL_OPTIONS: { value: ModelType; label: string; description: string }[] = [
   { value: 'gpt-5-mini', label: 'GPT-5-mini', description: 'Fast and efficient' },
@@ -18,6 +18,11 @@ const REASONING_OPTIONS: { value: ReasoningEffort; label: string }[] = [
   { value: 'low', label: 'Low' },
   { value: 'medium', label: 'Medium' },
   { value: 'high', label: 'High' },
+];
+
+const RESPONSE_LANGUAGE_OPTIONS: { value: ResponseLanguage; label: string }[] = [
+  { value: 'en', label: 'English' },
+  { value: 'zh', label: '中文' },
 ];
 
 const LANGUAGE_OPTIONS: { value: TranslateLanguage; label: string }[] = [
@@ -32,6 +37,7 @@ export function SettingsForm() {
   const updateModel = useStore((state) => state.updateModel);
   const updateReasoningEffort = useStore((state) => state.updateReasoningEffort);
   const updateWebSearchEnabled = useStore((state) => state.updateWebSearchEnabled);
+  const updateResponseLanguage = useStore((state) => state.updateResponseLanguage);
   const updateTranslateLanguage = useStore((state) => state.updateTranslateLanguage);
   const resetSettings = useStore((state) => state.resetSettings);
 
@@ -75,6 +81,30 @@ export function SettingsForm() {
               <RadioGroupItem value={option.value} id={`reasoning-${option.value}`} />
               <Label
                 htmlFor={`reasoning-${option.value}`}
+                className="cursor-pointer font-normal"
+              >
+                {option.label}
+              </Label>
+            </div>
+          ))}
+        </RadioGroup>
+      </div>
+
+      <Separator />
+
+      {/* Response Language */}
+      <div className="space-y-3">
+        <Label className="text-sm font-semibold">Response Language</Label>
+        <RadioGroup
+          value={settings.responseLanguage}
+          onValueChange={(value) => updateResponseLanguage(value as ResponseLanguage)}
+          className="grid grid-cols-2 gap-2"
+        >
+          {RESPONSE_LANGUAGE_OPTIONS.map((option) => (
+            <div key={option.value} className="flex items-center space-x-2">
+              <RadioGroupItem value={option.value} id={`response-lang-${option.value}`} />
+              <Label
+                htmlFor={`response-lang-${option.value}`}
                 className="cursor-pointer font-normal"
               >
                 {option.label}

--- a/lib/config/openai.ts
+++ b/lib/config/openai.ts
@@ -50,6 +50,60 @@ export const BLOCK_ACTION_PROMPT = `You transform or answer questions about a gi
 - Match the tone of the original text
 </rules>`;
 
+// Chinese variant of developer prompt
+export const DEVELOPER_PROMPT_ZH = `You are a knowledgeable assistant that provides deep, thorough explanations.
+
+<response_approach>
+- Always respond in Simplified Chinese (简体中文)
+- Start with a clear, direct answer or definition
+- Then explain the "why" and "how" behind it
+- Include relevant examples, edge cases, and practical implications
+- Connect to broader context when it aids understanding
+- Cover the topic completely — assume the user wants to truly understand, not just get a quick answer
+</response_approach>
+
+<structure>
+- Lead with the core concept (1-2 sentences)
+- Expand with supporting details and mechanisms
+- Add examples or analogies where helpful
+- Note important exceptions or nuances
+- Use headers (##) for distinct subtopics
+</structure>
+
+<formatting>
+- Use Markdown **only where semantically correct** (e.g., \`inline code\`, \`\`\`code fences\`\`\`, lists, tables)
+- Use backticks to format file, directory, function, and class names
+- Use \\( and \\) for inline math, \\[ and \\] for block math
+- NEVER use numbered lists (1, 2, 3). If sequence matters, use letters (a, b, c) instead
+</formatting>
+
+<avoid>
+- Repetition (don't restate the same point differently)
+- Filler phrases and unnecessary hedging
+- Artificial padding for simple topics
+</avoid>`;
+
+// Chinese variant of block action prompt
+export const BLOCK_ACTION_PROMPT_ZH = `You transform or answer questions about a given text block.
+
+<rules>
+- Always respond in Simplified Chinese (简体中文)
+- Output plain text only — no markdown, no bullet points, no numbered lists, no headers
+- No preamble ("Here's the translation:", "Sure!", etc.) — start directly with the result
+- Keep responses focused and concise — typically 1-3 sentences for questions, similar length to input for transformations
+- Match the tone of the original text
+</rules>`;
+
+// Helper to get the appropriate developer prompt based on response language
+export const getDeveloperPrompt = (responseLanguage: 'en' | 'zh' = 'en'): string => {
+  return responseLanguage === 'zh' ? DEVELOPER_PROMPT_ZH : DEVELOPER_PROMPT;
+};
+
+// Helper to get the appropriate block action prompt based on response language
+export const getBlockActionPrompt = (responseLanguage: 'en' | 'zh' = 'en'): string => {
+  return responseLanguage === 'zh' ? BLOCK_ACTION_PROMPT_ZH : BLOCK_ACTION_PROMPT;
+};
+
 // Model pricing per 1M tokens (January 2026)
 export const MODEL_PRICING: Record<string, { input: number; cachedInput: number; output: number }> = {
   'gpt-5.2': { input: 1.75, cachedInput: 0.175, output: 14.00 },

--- a/lib/state/settings.ts
+++ b/lib/state/settings.ts
@@ -3,7 +3,7 @@
  * These are pure functions with no side effects - testable and framework-agnostic
  */
 
-import type { Settings, ModelType, ReasoningEffort, TranslateLanguage } from '@/types/settings';
+import type { Settings, ModelType, ReasoningEffort, ResponseLanguage, TranslateLanguage } from '@/types/settings';
 import { DEFAULT_SETTINGS } from '@/types/settings';
 
 /**
@@ -38,6 +38,16 @@ export const updateWebSearchEnabled = (
   webSearchEnabled: boolean
 ): Settings => {
   return { ...settings, webSearchEnabled };
+};
+
+/**
+ * Update the response language setting
+ */
+export const updateResponseLanguage = (
+  settings: Settings,
+  responseLanguage: ResponseLanguage
+): Settings => {
+  return { ...settings, responseLanguage };
 };
 
 /**

--- a/lib/store/slices/settingsSlice.ts
+++ b/lib/store/slices/settingsSlice.ts
@@ -4,7 +4,7 @@
 
 import { StateCreator } from 'zustand';
 import * as settingsFns from '@/lib/state/settings';
-import type { Settings, ModelType, ReasoningEffort, TranslateLanguage } from '@/types/settings';
+import type { Settings, ModelType, ReasoningEffort, ResponseLanguage, TranslateLanguage } from '@/types/settings';
 
 export interface SettingsSlice {
   settings: Settings;
@@ -13,6 +13,7 @@ export interface SettingsSlice {
   updateModel: (model: ModelType) => void;
   updateReasoningEffort: (effort: ReasoningEffort) => void;
   updateWebSearchEnabled: (enabled: boolean) => void;
+  updateResponseLanguage: (language: ResponseLanguage) => void;
   updateTranslateLanguage: (language: TranslateLanguage) => void;
   resetSettings: () => void;
 }
@@ -37,6 +38,11 @@ export const settingsSlice: StateCreator<
 
   updateWebSearchEnabled: (enabled) => {
     const updated = settingsFns.updateWebSearchEnabled(get().settings, enabled);
+    set({ settings: updated });
+  },
+
+  updateResponseLanguage: (language) => {
+    const updated = settingsFns.updateResponseLanguage(get().settings, language);
     set({ settings: updated });
   },
 

--- a/tests/unit/lib/state/settings.test.ts
+++ b/tests/unit/lib/state/settings.test.ts
@@ -56,11 +56,13 @@ describe('Settings State Functions', () => {
         model: 'gpt-5-mini',
         reasoningEffort: 'high',
         webSearchEnabled: true,
+        responseLanguage: 'en',
         translateLanguage: 'English',
       };
       const updated = updateModel(settings, 'gpt-5.2');
       expect(updated.reasoningEffort).toBe('high');
       expect(updated.webSearchEnabled).toBe(true);
+      expect(updated.responseLanguage).toBe('en');
       expect(updated.translateLanguage).toBe('English');
     });
   });
@@ -102,11 +104,13 @@ describe('Settings State Functions', () => {
         model: 'gpt-5.2',
         reasoningEffort: 'none',
         webSearchEnabled: true,
+        responseLanguage: 'zh',
         translateLanguage: 'Spanish',
       };
       const updated = updateReasoningEffort(settings, 'medium');
       expect(updated.model).toBe('gpt-5.2');
       expect(updated.webSearchEnabled).toBe(true);
+      expect(updated.responseLanguage).toBe('zh');
       expect(updated.translateLanguage).toBe('Spanish');
     });
   });
@@ -136,11 +140,13 @@ describe('Settings State Functions', () => {
         model: 'gpt-5.2',
         reasoningEffort: 'high',
         webSearchEnabled: false,
+        responseLanguage: 'en',
         translateLanguage: 'French',
       };
       const updated = updateWebSearchEnabled(settings, true);
       expect(updated.model).toBe('gpt-5.2');
       expect(updated.reasoningEffort).toBe('high');
+      expect(updated.responseLanguage).toBe('en');
       expect(updated.translateLanguage).toBe('French');
     });
   });

--- a/types/settings.ts
+++ b/types/settings.ts
@@ -1,11 +1,13 @@
 export type ModelType = 'gpt-5.2' | 'gpt-5-mini';
 export type ReasoningEffort = 'none' | 'low' | 'medium' | 'high';
+export type ResponseLanguage = 'en' | 'zh';
 export type TranslateLanguage = 'English' | 'Chinese' | 'Spanish' | 'French';
 
 export interface Settings {
   model: ModelType;
   reasoningEffort: ReasoningEffort;
   webSearchEnabled: boolean;
+  responseLanguage: ResponseLanguage;
   translateLanguage: TranslateLanguage;
 }
 
@@ -13,5 +15,6 @@ export const DEFAULT_SETTINGS: Settings = {
   model: 'gpt-5-mini',
   reasoningEffort: 'none',
   webSearchEnabled: false,
+  responseLanguage: 'en',
   translateLanguage: 'Chinese',
 };


### PR DESCRIPTION
- Add ResponseLanguage type ('en' | 'zh') to settings
- Add Chinese variants of DEVELOPER_PROMPT and BLOCK_ACTION_PROMPT
- Add Response Language section to settings UI (before Translation Language)
- Wire up API routes to use language-specific prompts
- Default response language is English

https://claude.ai/code/session_019ycqo4nwDsjNBCiNsQyW6f