### PR TITLE
feat: add delete thread functionality

### DIFF
--- a/components/chat/ChatContainer.tsx
+++ b/components/chat/ChatContainer.tsx
@@ -10,6 +10,7 @@
 import { useEffect, useState } from 'react';
 import { MessageList } from './MessageList';
 import { Composer } from '@/components/composer/Composer';
+import { DeleteThreadButton } from './DeleteThreadButton';
 import { ExportButton } from './ExportButton';
 import { OfflineBanner } from './OfflineBanner';
 import { isOfflineMode } from '@/lib/utils/offlineMode';
@@ -198,10 +199,11 @@ export function ChatContainer({
 
   return (
     <div className="flex flex-col h-full">
-      {/* Toolbar with offline banner and export button */}
+      {/* Toolbar with offline banner, delete and export buttons */}
       <div className="chat-toolbar relative flex items-center justify-center px-4 border-b border-border/50 min-h-[52px]">
         {showOfflineBanner && <OfflineBanner />}
-        <div className="absolute right-4">
+        <div className="absolute right-4 flex items-center gap-2">
+          <DeleteThreadButton />
           <ExportButton />
         </div>
       </div>

--- a/components/chat/DeleteThreadButton.tsx
+++ b/components/chat/DeleteThreadButton.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { useStore, selectActiveThread } from '@/lib/store/useStore';
+
+/**
+ * Delete thread button with confirmation dialog
+ *
+ * - Shows trash icon button in toolbar
+ * - Opens confirmation dialog with thread title and message count
+ * - Navigates to adjacent thread or home page after deletion
+ */
+export function DeleteThreadButton() {
+  const router = useRouter();
+  const activeThread = useStore(selectActiveThread);
+  const deleteThread = useStore((state) => state.deleteThread);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  const messageCount = activeThread?.messages.length ?? 0;
+
+  const handleDelete = async () => {
+    if (!activeThread) return;
+
+    setIsDeleting(true);
+    try {
+      const nextThreadId = deleteThread(activeThread.id);
+
+      // Navigate to next thread or home page
+      if (nextThreadId) {
+        router.push(`/t/${nextThreadId}`);
+      } else {
+        router.push('/');
+      }
+    } finally {
+      setIsDeleting(false);
+      setOpen(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          title="Delete thread"
+          aria-label="Delete thread"
+          className="text-muted-foreground hover:text-destructive"
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete Thread</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to delete &quot;{activeThread?.title ?? 'this thread'}&quot;?
+            {messageCount > 0 && (
+              <span className="block mt-2">
+                This thread contains {messageCount} message{messageCount !== 1 ? 's' : ''}.
+              </span>
+            )}
+            <span className="block mt-2 text-destructive">
+              This action cannot be undone.
+            </span>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleDelete}
+            disabled={isDeleting}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {isDeleting ? 'Deleting...' : 'Delete'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/hooks/useComposer.ts
+++ b/hooks/useComposer.ts
@@ -166,6 +166,11 @@ export function useComposer(): UseComposerReturn {
 
       // IMPORTANT: Get fresh activeThreadId from store (after potential createThread())
       const currentThreadId = useStore.getState().activeThreadId;
+      if (!currentThreadId) {
+        setError('No active thread');
+        setAwaitingResponse(false);
+        return;
+      }
 
       // Update thread title ONLY for the first message (when creating new thread)
       if (isNewThread) {

--- a/lib/state/message.ts
+++ b/lib/state/message.ts
@@ -36,6 +36,9 @@ export const addUserMessage = (
   nowFactory: () => number
 ): AddMessageResult => {
   const threadId = state.activeThreadId;
+  if (!threadId) {
+    throw new Error('Cannot add message: no active thread');
+  }
   const messageId = idFactory();
   const message: Message = {
     id: messageId,
@@ -70,9 +73,13 @@ export const addAssistantMessage = (
   nowFactory: () => number,
   responseId?: string
 ): AddMessageResult => {
+  const threadId = state.activeThreadId;
+  if (!threadId) {
+    throw new Error('Cannot add message: no active thread');
+  }
   return addAssistantMessageToThread(
     state,
-    state.activeThreadId,
+    threadId,
     blocksData,
     idFactory,
     nowFactory,

--- a/lib/state/thread.ts
+++ b/lib/state/thread.ts
@@ -167,7 +167,7 @@ export const deleteThread = (
       threads: remainingThreads,
       blocks: filteredBlocks,
       cards: filteredCards,
-      activeThreadId: nextActiveThreadId ?? state.activeThreadId,
+      activeThreadId: nextActiveThreadId,
     },
     nextActiveThreadId,
   };

--- a/lib/state/thread.ts
+++ b/lib/state/thread.ts
@@ -113,3 +113,62 @@ export const getLastAssistantResponseId = (
 
   return undefined;
 };
+
+/**
+ * Result of deleteThread - contains updated state and next thread to navigate to
+ */
+export interface DeleteThreadResult {
+  state: AppState;
+  nextActiveThreadId: string | null;
+}
+
+/**
+ * Delete a thread from state
+ *
+ * - Removes thread from threads array
+ * - Removes all blocks belonging to that thread's messages
+ * - Removes all cards belonging to that thread's messages
+ * - Determines the next active thread (previous > next > null)
+ *
+ * @param state - Current application state
+ * @param threadId - ID of the thread to delete
+ * @returns New state with thread removed and next active thread ID
+ */
+export const deleteThread = (
+  state: AppState,
+  threadId: string
+): DeleteThreadResult => {
+  const thread = getThreadById(state, threadId);
+  if (!thread) {
+    return { state, nextActiveThreadId: state.activeThreadId };
+  }
+
+  // Get message IDs for the thread to filter blocks and cards
+  const messageIds = new Set(thread.messages.map((m) => m.id));
+
+  // Determine next active thread
+  const threadIndex = state.threads.findIndex((t) => t.id === threadId);
+  const remainingThreads = state.threads.filter((t) => t.id !== threadId);
+
+  let nextActiveThreadId: string | null = null;
+  if (remainingThreads.length > 0) {
+    // Prefer previous thread, fall back to next (which is now at same index)
+    const nextIndex = Math.min(threadIndex, remainingThreads.length - 1);
+    nextActiveThreadId = remainingThreads[nextIndex >= 0 ? nextIndex : 0].id;
+  }
+
+  // Filter out blocks and cards belonging to the deleted thread
+  const filteredBlocks = state.blocks.filter((b) => !messageIds.has(b.messageId));
+  const filteredCards = state.cards.filter((c) => !messageIds.has(c.messageId));
+
+  return {
+    state: {
+      ...state,
+      threads: remainingThreads,
+      blocks: filteredBlocks,
+      cards: filteredCards,
+      activeThreadId: nextActiveThreadId ?? state.activeThreadId,
+    },
+    nextActiveThreadId,
+  };
+};

--- a/lib/store/slices/threadSlice.ts
+++ b/lib/store/slices/threadSlice.ts
@@ -7,7 +7,7 @@ import * as stateFns from '@/lib/state';
 import { idFactory } from '@/lib/utils/idFactory';
 import { nowFactory } from '@/lib/utils/nowFactory';
 import { isTestMode } from '@/lib/utils/testMode';
-import { persistThreadSnapshot, updateThreadMetadata } from '@/lib/supabase/threads';
+import { persistThreadSnapshot, updateThreadMetadata, deleteThreadFromSupabase } from '@/lib/supabase/threads';
 import { Thread } from '@/types/thread';
 import { Message } from '@/types/message';
 import { Block, BlockData } from '@/types/block';
@@ -21,6 +21,7 @@ export interface ThreadSlice {
   createThread: (threadId?: string) => void;
   setActiveThread: (threadId: string) => void;
   updateThreadTitle: (threadId: string, title: string) => void;
+  deleteThread: (threadId: string) => string | null;
   addUserMessage: (text: string) => { message: Message; blocks: Block[] };
   addAssistantMessage: (blocksData: BlockData[], responseId?: string) => { message: Message; blocks: Block[] };
   mergeThreadFromSupabase: (thread: Thread, messages: Message[], blocks: Block[]) => void;
@@ -76,6 +77,28 @@ export const threadSlice: StateCreator<
         new Date(thread.updatedAt).toISOString()
       ).catch((error) => console.error('Failed to update thread metadata:', error));
     }
+  },
+
+  deleteThread: (threadId) => {
+    const result = stateFns.deleteThread(get(), threadId);
+
+    // Update local state immediately (optimistic update)
+    set({
+      threads: result.state.threads,
+      blocks: result.state.blocks,
+      cards: result.state.cards,
+      activeThreadId: result.state.activeThreadId,
+    });
+
+    // Skip database persistence in test mode
+    if (!isTestMode()) {
+      // Async database delete (non-blocking)
+      deleteThreadFromSupabase(threadId).catch((error) =>
+        console.error('Failed to delete thread from database:', error)
+      );
+    }
+
+    return result.nextActiveThreadId;
   },
 
   addUserMessage: (text) => {

--- a/lib/store/slices/threadSlice.ts
+++ b/lib/store/slices/threadSlice.ts
@@ -15,7 +15,7 @@ import { AppState } from '@/types/state';
 
 export interface ThreadSlice {
   threads: Thread[];
-  activeThreadId: string;
+  activeThreadId: string | null;
 
   // Actions that wrap pure functions
   createThread: (threadId?: string) => void;
@@ -83,12 +83,24 @@ export const threadSlice: StateCreator<
     const result = stateFns.deleteThread(get(), threadId);
 
     // Update local state immediately (optimistic update)
-    set({
-      threads: result.state.threads,
-      blocks: result.state.blocks,
-      cards: result.state.cards,
-      activeThreadId: result.state.activeThreadId,
-    });
+    // If no threads remain, switch to landing mode
+    if (result.nextActiveThreadId === null) {
+      set({
+        threads: result.state.threads,
+        blocks: result.state.blocks,
+        cards: result.state.cards,
+        activeThreadId: result.state.activeThreadId,
+        mode: 'landing',
+        selectedBlockId: null,
+      });
+    } else {
+      set({
+        threads: result.state.threads,
+        blocks: result.state.blocks,
+        cards: result.state.cards,
+        activeThreadId: result.state.activeThreadId,
+      });
+    }
 
     // Skip database persistence in test mode
     if (!isTestMode()) {
@@ -115,7 +127,7 @@ export const threadSlice: StateCreator<
     });
 
     // Skip database persistence in test mode
-    if (!isTestMode()) {
+    if (!isTestMode() && result.state.activeThreadId) {
       // Async persistence (non-blocking)
       const activeThread = stateFns.getThreadById(
         result.state,
@@ -152,9 +164,13 @@ export const threadSlice: StateCreator<
   },
 
   addAssistantMessage: (blocksData, responseId) => {
+    const currentActiveThreadId = get().activeThreadId;
+    if (!currentActiveThreadId) {
+      throw new Error('Cannot add assistant message: no active thread');
+    }
     const result = stateFns.addAssistantMessageToThread(
       get(),
-      get().activeThreadId,
+      currentActiveThreadId,
       blocksData,
       idFactory,
       nowFactory,
@@ -167,7 +183,7 @@ export const threadSlice: StateCreator<
     });
 
     // Skip database persistence in test mode
-    if (!isTestMode()) {
+    if (!isTestMode() && result.state.activeThreadId) {
       // Async persistence (non-blocking)
       const activeThread = stateFns.getThreadById(
         result.state,

--- a/lib/supabase/threads.ts
+++ b/lib/supabase/threads.ts
@@ -134,6 +134,25 @@ export const updateThreadMetadata = async (
 };
 
 /**
+ * Delete a thread from Supabase
+ * Cascade delete handles removing related messages and blocks automatically
+ */
+export const deleteThreadFromSupabase = async (threadId: string): Promise<void> => {
+  return withSupabaseClient(
+    async (supabase) => {
+      const { error } = await supabase
+        .from('threads')
+        .delete()
+        .eq('id', threadId);
+
+      if (error) throw error;
+    },
+    undefined,
+    `deleting thread ${threadId}`
+  );
+};
+
+/**
  * Convert DB thread to app thread
  */
 const dbThreadToThread = (dbThread: DbThread): Thread => ({

--- a/tests/unit/integration/user-flows.test.tsx
+++ b/tests/unit/integration/user-flows.test.tsx
@@ -200,10 +200,10 @@ describe('User Flow Tests', () => {
       
       // Current active should be thread 2
       expect(useStore.getState().activeThreadId).toBe(thread2Id);
-      
+
       // Switch back to thread 1
-      setActiveThread(thread1Id);
-      
+      setActiveThread(thread1Id!);
+
       const state = useStore.getState();
       expect(state.activeThreadId).toBe(thread1Id);
     });

--- a/tests/unit/lib/state/index.test.ts
+++ b/tests/unit/lib/state/index.test.ts
@@ -80,7 +80,7 @@ describe('State Management - Core Functions', () => {
 
   describe('updateThreadTitle', () => {
     it('should update thread title and updatedAt', () => {
-      const threadId = state.activeThreadId;
+      const threadId = state.activeThreadId!;
       const nextState = updateThreadTitle(state, threadId, 'New Title', nowFactory);
       const thread = getThreadById(nextState, threadId);
       expect(thread?.title).toBe('New Title');
@@ -88,7 +88,7 @@ describe('State Management - Core Functions', () => {
     });
 
     it('should not modify other threads', () => {
-      const firstThreadId = state.activeThreadId;
+      const firstThreadId = state.activeThreadId!;
       const secondThread = createThread(state, 'thread-2', nowFactory, 'Second');
       state = secondThread.state;
       // Update the first thread, not the active thread (which is thread-2)
@@ -173,7 +173,7 @@ describe('State Management - Core Functions', () => {
       expect(result.blocks[0].text).toBe('Hello world');
       expect(result.state.blocks).toHaveLength(1);
 
-      const thread = getThreadById(result.state, state.activeThreadId);
+      const thread = getThreadById(result.state, state.activeThreadId!);
       expect(thread?.messages).toHaveLength(1);
     });
   });
@@ -190,7 +190,7 @@ describe('State Management - Core Functions', () => {
       expect(result.blocks).toHaveLength(2);
       expect(result.state.blocks).toHaveLength(2);
 
-      const thread = getThreadById(result.state, state.activeThreadId);
+      const thread = getThreadById(result.state, state.activeThreadId!);
       expect(thread?.messages).toHaveLength(1);
       expect(thread?.messages[0].content).toHaveLength(2);
     });
@@ -247,7 +247,7 @@ describe('State Management - Core Functions', () => {
       const blocksData = [{ text: 'Response', type: 'paragraph' as const }];
       const result = addAssistantMessageToThread(
         state,
-        state.activeThreadId,
+        state.activeThreadId!,
         blocksData,
         idFactory,
         nowFactory,
@@ -260,7 +260,7 @@ describe('State Management - Core Functions', () => {
 
   describe('getLastAssistantResponseId', () => {
     it('should return undefined when thread has no messages', () => {
-      const responseId = getLastAssistantResponseId(state, state.activeThreadId);
+      const responseId = getLastAssistantResponseId(state, state.activeThreadId!);
       expect(responseId).toBeUndefined();
     });
 
@@ -271,21 +271,21 @@ describe('State Management - Core Functions', () => {
 
     it('should return undefined when only user messages exist', () => {
       const result = addUserMessage(state, 'Hello', idFactory, nowFactory);
-      const responseId = getLastAssistantResponseId(result.state, state.activeThreadId);
+      const responseId = getLastAssistantResponseId(result.state, state.activeThreadId!);
       expect(responseId).toBeUndefined();
     });
 
     it('should return undefined when assistant message has no responseId', () => {
       const blocksData = [{ text: 'Response', type: 'paragraph' as const }];
       const result = addAssistantMessage(state, blocksData, idFactory, nowFactory);
-      const responseId = getLastAssistantResponseId(result.state, state.activeThreadId);
+      const responseId = getLastAssistantResponseId(result.state, state.activeThreadId!);
       expect(responseId).toBeUndefined();
     });
 
     it('should return responseId from last assistant message', () => {
       const blocksData = [{ text: 'Response', type: 'paragraph' as const }];
       const result = addAssistantMessage(state, blocksData, idFactory, nowFactory, 'resp_first');
-      const responseId = getLastAssistantResponseId(result.state, state.activeThreadId);
+      const responseId = getLastAssistantResponseId(result.state, state.activeThreadId!);
       expect(responseId).toBe('resp_first');
     });
 
@@ -301,7 +301,7 @@ describe('State Management - Core Functions', () => {
       // Add second assistant message
       currentState = addAssistantMessage(currentState, blocksData, idFactory, nowFactory, 'resp_second').state;
 
-      const responseId = getLastAssistantResponseId(currentState, state.activeThreadId);
+      const responseId = getLastAssistantResponseId(currentState, state.activeThreadId!);
       expect(responseId).toBe('resp_second');
     });
 
@@ -317,7 +317,7 @@ describe('State Management - Core Functions', () => {
       // Should still return the first responseId since the latest doesn't have one
       // Actually, wait - it searches backwards and the latest message doesn't have openaiResponseId
       // so it will skip it and return resp_first
-      const responseId = getLastAssistantResponseId(currentState, state.activeThreadId);
+      const responseId = getLastAssistantResponseId(currentState, state.activeThreadId!);
       expect(responseId).toBe('resp_first');
     });
   });

--- a/types/state/core.ts
+++ b/types/state/core.ts
@@ -12,7 +12,7 @@ import { Block } from '../block';
 import { Card } from '../card';
 
 export interface CoreState {
-  activeThreadId: string;
+  activeThreadId: string | null;
   threads: Thread[];
   blocks: Block[];
   cards: Card[];


### PR DESCRIPTION
## Summary
- Add delete thread button with confirmation dialog in chat toolbar
- Implement full data flow: UI → Store → Pure state → Database
- Handle edge cases for navigation after deletion

## Changes
| File | Change |
|------|--------|
| `lib/supabase/threads.ts` | Add `deleteThreadFromSupabase()` |
| `lib/state/thread.ts` | Add `deleteThread()` pure function |
| `lib/store/slices/threadSlice.ts` | Add `deleteThread` action |
| `components/chat/DeleteThreadButton.tsx` | New component with AlertDialog |
| `components/chat/ChatContainer.tsx` | Integrate delete button |

## User Flow
1. Click trash icon in chat toolbar (left of Export button)
2. AlertDialog shows thread title and message count
3. Confirm deletion
4. Thread removed, navigate to adjacent thread or home

## Edge Cases
- **Delete last thread**: Navigates to `/`
- **Delete active thread**: Navigates to previous or next thread
- **DB error**: Local state updated optimistically; error logged

## Test plan
- [ ] Create a thread with messages
- [ ] Click delete button, verify dialog shows thread info
- [ ] Cancel deletion, verify no changes
- [ ] Confirm deletion, verify navigation to adjacent thread
- [ ] Delete last thread, verify navigation to home
- [ ] Verify thread removed from sidebar

🤖 Generated with [Claude Code](https://claude.ai/code)