### PR TITLE
feat: direct block editing with Ask/Edit toggle

### DIFF
--- a/components/chat/BlockControls.tsx
+++ b/components/chat/BlockControls.tsx
@@ -21,8 +21,8 @@ export function BlockControls({ onAction, disabled = false }: BlockControlsProps
   const actions: { action: UIBlockAction; label: string }[] = [
     { action: 'translate', label: 'Translate' },
     { action: 'example', label: 'Example' },
-    { action: 'eli5', label: 'ELI5' },
     { action: 'expand', label: 'Expand' },
+    { action: 'eli5', label: 'ELI5' },
   ];
 
   const handleClick = (e: React.MouseEvent, action: UIBlockAction) => {

--- a/components/chat/ChatContainer.tsx
+++ b/components/chat/ChatContainer.tsx
@@ -7,7 +7,7 @@
 
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { MessageList } from './MessageList';
 import { Composer } from '@/components/composer/Composer';
 import { DeleteThreadButton } from './DeleteThreadButton';
@@ -74,6 +74,9 @@ export function ChatContainer({
     handleSubmit,
     isSubmitting,
     handleBlockAction,
+    composerMode,
+    setComposerMode,
+    populateWithBlockText,
   } = useComposer();
 
   // Error state from store (persists across navigation)
@@ -185,6 +188,18 @@ export function ChatContainer({
     handleSubmit();
   };
 
+  // Handle composer mode change (Ask/Edit toggle)
+  const handleComposerModeChange = useCallback((mode: 'ask' | 'edit') => {
+    setComposerMode(mode);
+    if (mode === 'edit') {
+      // Populate composer with block text when switching to edit mode
+      populateWithBlockText();
+    } else if (mode === 'ask') {
+      // Clear prompt when switching to ask mode
+      setPrompt('');
+    }
+  }, [setComposerMode, populateWithBlockText, setPrompt]);
+
   // Combined error (thread loading or composer)
   const error = threadError || composerError;
 
@@ -238,6 +253,8 @@ export function ChatContainer({
             onSubmit={handleSubmit}
             onSelectionCapture={captureSelection}
             onBlockAction={handleBlockAction}
+            composerMode={composerMode}
+            onComposerModeChange={handleComposerModeChange}
             disabled={isComposerDisabled}
           />
         </div>

--- a/components/chat/DocBlock.tsx
+++ b/components/chat/DocBlock.tsx
@@ -116,14 +116,27 @@ function DocBlockComponent({
       <div className="doc-content">
         <BlockContent text={block.text} type={block.type} />
 
-        {/* Selection chips (only show when selected) */}
-        {isSelected && (
+        {/* Selection chips (only show when selected and has selections) */}
+        {isSelected && block.selections.length > 0 && (
           <SelectionChips
             block={block}
             onRemoveSelection={(index) => onRemoveSelection?.(block.id, index)}
             onRewrite={() => onRewrite?.(block.id)}
             onUndo={() => onUndo?.(block.id)}
           />
+        )}
+
+        {/* Standalone undo button (when selected, has prevText, but no selections) */}
+        {isSelected && block.prevText != null && block.selections.length === 0 && (
+          <div className="block-chips">
+            <button
+              type="button"
+              className="chip-undo"
+              onClick={() => onUndo?.(block.id)}
+            >
+              Undo
+            </button>
+          </div>
         )}
       </div>
     </div>

--- a/components/composer/BlockModeToggle.tsx
+++ b/components/composer/BlockModeToggle.tsx
@@ -14,12 +14,12 @@ interface BlockModeToggleProps {
  */
 export function BlockModeToggle({ mode, onModeChange, disabled = false }: BlockModeToggleProps) {
   return (
-    <div className="inline-flex rounded-lg border border-border bg-muted p-0.5">
+    <div className="inline-flex rounded border border-border bg-muted p-0.5">
       <button
         type="button"
         onClick={() => onModeChange('ask')}
         disabled={disabled}
-        className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
+        className={`px-2 py-0.5 text-xs font-medium rounded-sm transition-colors ${
           mode === 'ask'
             ? 'bg-background text-foreground shadow-sm'
             : 'text-muted-foreground hover:text-foreground'
@@ -32,7 +32,7 @@ export function BlockModeToggle({ mode, onModeChange, disabled = false }: BlockM
         type="button"
         onClick={() => onModeChange('edit')}
         disabled={disabled}
-        className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
+        className={`px-2 py-0.5 text-xs font-medium rounded-sm transition-colors ${
           mode === 'edit'
             ? 'bg-background text-foreground shadow-sm'
             : 'text-muted-foreground hover:text-foreground'

--- a/components/composer/BlockModeToggle.tsx
+++ b/components/composer/BlockModeToggle.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import type { ComposerMode } from '@/types/state/ui';
+
+interface BlockModeToggleProps {
+  mode: 'ask' | 'edit';
+  onModeChange: (mode: 'ask' | 'edit') => void;
+  disabled?: boolean;
+}
+
+/**
+ * Segmented toggle for switching between Ask and Edit modes
+ * Only shown when a block is selected (mode is not 'chat')
+ */
+export function BlockModeToggle({ mode, onModeChange, disabled = false }: BlockModeToggleProps) {
+  return (
+    <div className="inline-flex rounded-lg border border-border bg-muted p-0.5">
+      <button
+        type="button"
+        onClick={() => onModeChange('ask')}
+        disabled={disabled}
+        className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
+          mode === 'ask'
+            ? 'bg-background text-foreground shadow-sm'
+            : 'text-muted-foreground hover:text-foreground'
+        } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+        aria-pressed={mode === 'ask'}
+      >
+        Ask
+      </button>
+      <button
+        type="button"
+        onClick={() => onModeChange('edit')}
+        disabled={disabled}
+        className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
+          mode === 'edit'
+            ? 'bg-background text-foreground shadow-sm'
+            : 'text-muted-foreground hover:text-foreground'
+        } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+        aria-pressed={mode === 'edit'}
+      >
+        Edit
+      </button>
+    </div>
+  );
+}

--- a/components/composer/Composer.tsx
+++ b/components/composer/Composer.tsx
@@ -45,14 +45,17 @@ export function Composer({
       onSubmit={onSubmit}
       className="composer bg-background rounded-xl border border-border composer-shadow p-4 max-h-[50vh] flex flex-col overflow-hidden w-full"
     >
-      {/* Ask/Edit toggle - shown when block is selected */}
+      {/* Ask/Edit toggle + Block actions - shown when block is selected */}
       {hasBlockSelected && onComposerModeChange && (
-        <div className="mb-3 flex-shrink-0">
+        <div className="mb-3 flex-shrink-0 flex items-center gap-3">
           <BlockModeToggle
             mode={composerMode === 'edit' ? 'edit' : 'ask'}
             onModeChange={onComposerModeChange}
             disabled={disabled}
           />
+          {showBlockControls && (
+            <BlockControls onAction={onBlockAction} disabled={disabled} />
+          )}
         </div>
       )}
 
@@ -75,12 +78,6 @@ export function Composer({
           </span>
         </Button>
       </div>
-
-      {showBlockControls && (
-        <div className="mt-2 flex-shrink-0">
-          <BlockControls onAction={onBlockAction} disabled={disabled} />
-        </div>
-      )}
 
       <ComposerHint hidden={hasBlockSelected} />
     </form>

--- a/components/composer/Composer.tsx
+++ b/components/composer/Composer.tsx
@@ -3,8 +3,10 @@
 import { FormEvent } from 'react';
 import { PromptInput } from './PromptInput';
 import { ComposerHint } from './ComposerHint';
+import { BlockModeToggle } from './BlockModeToggle';
 import { BlockControls, UIBlockAction } from '@/components/chat/BlockControls';
 import { Button } from '@/components/ui/button';
+import type { ComposerMode } from '@/types/state/ui';
 
 /**
  * Client Component - Main composer form
@@ -17,6 +19,8 @@ interface ComposerProps {
   onSubmit: (e: FormEvent) => void;
   onSelectionCapture?: (element: HTMLElement | null) => void;
   onBlockAction?: (action: UIBlockAction) => void;
+  composerMode?: ComposerMode;
+  onComposerModeChange?: (mode: 'ask' | 'edit') => void;
   disabled?: boolean;
 }
 
@@ -27,36 +31,52 @@ export function Composer({
   onSubmit,
   onSelectionCapture,
   onBlockAction,
+  composerMode = 'chat',
+  onComposerModeChange,
   disabled = false,
 }: ComposerProps) {
-  // Show block controls when a block is selected
+  // Show block controls when a block is selected and in ask mode
   const hasBlockSelected = !!selectedBlockId;
+  const isEditMode = composerMode === 'edit';
+  const showBlockControls = hasBlockSelected && composerMode === 'ask';
 
   return (
     <form
       onSubmit={onSubmit}
       className="composer bg-background rounded-xl border border-border composer-shadow p-4 max-h-[50vh] flex flex-col overflow-hidden w-full"
     >
+      {/* Ask/Edit toggle - shown when block is selected */}
+      {hasBlockSelected && onComposerModeChange && (
+        <div className="mb-3 flex-shrink-0">
+          <BlockModeToggle
+            mode={composerMode === 'edit' ? 'edit' : 'ask'}
+            onModeChange={onComposerModeChange}
+            disabled={disabled}
+          />
+        </div>
+      )}
+
       <div className="flex gap-2 items-stretch flex-1 min-h-0">
         <div className="flex-1 min-h-0 min-w-0">
           <PromptInput
             value={prompt}
             onChange={onPromptChange}
-            onSelectionCapture={onSelectionCapture}
+            onSelectionCapture={isEditMode ? undefined : onSelectionCapture}
             onSubmit={() => onSubmit(new Event('submit') as any)}
             disabled={disabled}
             hasBlockSelected={hasBlockSelected}
+            composerMode={composerMode}
           />
         </div>
         <Button type="submit" variant="default" disabled={disabled} className="flex-shrink-0 self-end">
-          <span>Send</span>
+          <span>{isEditMode ? 'Replace' : 'Send'}</span>
           <span aria-hidden="true" className="ml-1">
-            →
+            {isEditMode ? '↻' : '→'}
           </span>
         </Button>
       </div>
 
-      {hasBlockSelected && (
+      {showBlockControls && (
         <div className="mt-2 flex-shrink-0">
           <BlockControls onAction={onBlockAction} disabled={disabled} />
         </div>

--- a/components/composer/PromptInput.tsx
+++ b/components/composer/PromptInput.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRef, useEffect } from 'react';
+import type { ComposerMode } from '@/types/state/ui';
 
 /**
  * Client Component - Contenteditable input with text selection capture
@@ -17,6 +18,7 @@ interface PromptInputProps {
   placeholder?: string;
   disabled?: boolean;
   hasBlockSelected?: boolean;
+  composerMode?: ComposerMode;
 }
 
 export function PromptInput({
@@ -27,13 +29,20 @@ export function PromptInput({
   placeholder,
   disabled = false,
   hasBlockSelected = false,
+  composerMode = 'chat',
 }: PromptInputProps) {
-  // Set default placeholder based on block selection state
-  const defaultPlaceholder = hasBlockSelected
-    ? 'Ask about the selected block'
-    : 'Ask coo anything';
+  // Set default placeholder based on composer mode
+  const getDefaultPlaceholder = () => {
+    if (composerMode === 'edit') {
+      return 'Type new content to replace the selected block';
+    }
+    if (hasBlockSelected) {
+      return 'Ask about the selected block';
+    }
+    return 'Ask coo anything';
+  };
 
-  const finalPlaceholder = placeholder || defaultPlaceholder;
+  const finalPlaceholder = placeholder || getDefaultPlaceholder();
   const inputRef = useRef<HTMLDivElement>(null);
   const isUserInputRef = useRef<boolean>(false);
   // Track mouse drag state for selection capture (only drag creates chips, not clicks)

--- a/components/composer/PromptInput.tsx
+++ b/components/composer/PromptInput.tsx
@@ -101,6 +101,44 @@ export function PromptInput({
       if (onSubmit) {
         onSubmit();
       }
+      return;
+    }
+
+    // In edit mode: convert backspace/delete to strikethrough when ALL text is selected
+    if (composerMode === 'edit' && (e.key === 'Backspace' || e.key === 'Delete')) {
+      const selection = window.getSelection();
+      if (!selection || selection.isCollapsed || !inputRef.current) return;
+
+      const selectedText = selection.toString();
+      const fullText = inputRef.current.textContent || '';
+
+      // Only apply strikethrough if ALL text is selected
+      if (!selectedText || selectedText.length !== fullText.length) return;
+
+      e.preventDefault();
+
+      // Wrap entire text in strikethrough
+      const newText = '~~' + fullText + '~~';
+
+      isUserInputRef.current = true;
+      onChange(newText.replace(/\u00a0/g, ' ').trim());
+
+      // Update DOM and position cursor at the end
+      inputRef.current.textContent = newText;
+
+      try {
+        const textNode = inputRef.current.firstChild;
+        if (textNode && selection) {
+          const newRange = document.createRange();
+          const maxOffset = (textNode.textContent || '').length;
+          newRange.setStart(textNode, maxOffset);
+          newRange.collapse(true);
+          selection.removeAllRanges();
+          selection.addRange(newRange);
+        }
+      } catch (err) {
+        // Ignore cursor positioning errors
+      }
     }
   };
 

--- a/components/content/BlockContent.tsx
+++ b/components/content/BlockContent.tsx
@@ -120,6 +120,9 @@ function renderSegment(segment: MarkdownSegment, index: number): React.ReactNode
       // Recursively parse content for nested bold/links
       return <em key={index}>{parseNestedFormatting(segment.content, 'italic')}</em>;
 
+    case 'strikethrough':
+      return <del key={index}>{segment.content}</del>;
+
     case 'link':
       return (
         <a

--- a/e2e/mock/direct-edit.spec.ts
+++ b/e2e/mock/direct-edit.spec.ts
@@ -1,0 +1,353 @@
+import { test, expect } from '@playwright/test';
+import { LandingPage } from '../page-objects/LandingPage';
+import { ChatPage } from '../page-objects/ChatPage';
+import { ApiMocker } from '../utils/api-mocks';
+
+/**
+ * Tests for Direct Block Editing feature
+ * - Ask/Edit toggle visibility and mode switching
+ * - Edit mode composer population
+ * - Replace button and direct block updates
+ * - Undo after direct edit
+ * - Strikethrough on select-all + delete
+ */
+
+const SIMPLE_RESPONSE = {
+  text: 'React is a JavaScript library for building user interfaces.',
+};
+
+test.describe('Direct Edit - Toggle Visibility', () => {
+  let landingPage: LandingPage;
+  let chatPage: ChatPage;
+  let apiMocker: ApiMocker;
+
+  test.beforeEach(async ({ page }) => {
+    landingPage = new LandingPage(page);
+    chatPage = new ChatPage(page);
+    apiMocker = new ApiMocker(page);
+
+    await page.addInitScript(() => {
+      (window as any).__TEST_MODE__ = true;
+    });
+
+    await landingPage.goto();
+    await apiMocker.mockChatSuccess(SIMPLE_RESPONSE);
+    await landingPage.submitFirstPrompt('Explain React');
+    await page.waitForURL(/\/t\/.+/);
+    await chatPage.waitForResponse();
+  });
+
+  test('should show Ask/Edit toggle when block is selected', async () => {
+    // Initially no toggle visible
+    expect(await chatPage.isModeToggleVisible()).toBe(false);
+
+    // Select a block
+    await chatPage.selectBlock(0);
+
+    // Toggle should appear
+    expect(await chatPage.isModeToggleVisible()).toBe(true);
+  });
+
+  test('should hide toggle when block is deselected', async () => {
+    // Select block
+    await chatPage.selectBlock(0);
+    expect(await chatPage.isModeToggleVisible()).toBe(true);
+
+    // Deselect with Escape
+    await chatPage.deselectAll();
+
+    // Toggle should disappear
+    expect(await chatPage.isModeToggleVisible()).toBe(false);
+  });
+
+  test('should default to Ask mode when block is selected', async () => {
+    await chatPage.selectBlock(0);
+
+    expect(await chatPage.isInAskMode()).toBe(true);
+    expect(await chatPage.isInEditMode()).toBe(false);
+  });
+});
+
+test.describe('Direct Edit - Mode Switching', () => {
+  let landingPage: LandingPage;
+  let chatPage: ChatPage;
+  let apiMocker: ApiMocker;
+
+  test.beforeEach(async ({ page }) => {
+    landingPage = new LandingPage(page);
+    chatPage = new ChatPage(page);
+    apiMocker = new ApiMocker(page);
+
+    await page.addInitScript(() => {
+      (window as any).__TEST_MODE__ = true;
+    });
+
+    await landingPage.goto();
+    await apiMocker.mockChatSuccess(SIMPLE_RESPONSE);
+    await landingPage.submitFirstPrompt('Explain React');
+    await page.waitForURL(/\/t\/.+/);
+    await chatPage.waitForResponse();
+  });
+
+  test('should switch to Edit mode and populate composer with block text', async () => {
+    // Get original block text
+    const blockText = await chatPage.getBlockText(0);
+
+    // Select block and switch to Edit mode
+    await chatPage.selectBlock(0);
+    await chatPage.clickEditMode();
+
+    // Verify Edit mode is active
+    expect(await chatPage.isInEditMode()).toBe(true);
+
+    // Verify composer is populated with block text
+    const composerText = await chatPage.getPromptValue();
+    expect(composerText).toBe(blockText);
+  });
+
+  test('should clear composer when switching back to Ask mode', async () => {
+    await chatPage.selectBlock(0);
+    await chatPage.clickEditMode();
+
+    // Verify composer has text
+    const textInEdit = await chatPage.getPromptValue();
+    expect(textInEdit.length).toBeGreaterThan(0);
+
+    // Switch back to Ask mode
+    await chatPage.clickAskMode();
+
+    // Verify composer is cleared
+    const textInAsk = await chatPage.getPromptValue();
+    expect(textInAsk).toBe('');
+  });
+
+  test('should show Replace button in Edit mode', async () => {
+    await chatPage.selectBlock(0);
+
+    // In Ask mode, button says "Send"
+    let buttonText = await chatPage.getSubmitButtonText();
+    expect(buttonText).toContain('Send');
+
+    // Switch to Edit mode
+    await chatPage.clickEditMode();
+
+    // Button should say "Replace"
+    buttonText = await chatPage.getSubmitButtonText();
+    expect(buttonText).toContain('Replace');
+  });
+
+  test('should hide block controls in Edit mode', async () => {
+    await chatPage.selectBlock(0);
+
+    // In Ask mode, block controls visible
+    await expect(chatPage.blockControls).toBeVisible();
+
+    // Switch to Edit mode
+    await chatPage.clickEditMode();
+
+    // Block controls should be hidden
+    await expect(chatPage.blockControls).not.toBeVisible();
+  });
+});
+
+test.describe('Direct Edit - Block Replacement', () => {
+  let landingPage: LandingPage;
+  let chatPage: ChatPage;
+  let apiMocker: ApiMocker;
+
+  test.beforeEach(async ({ page }) => {
+    landingPage = new LandingPage(page);
+    chatPage = new ChatPage(page);
+    apiMocker = new ApiMocker(page);
+
+    await page.addInitScript(() => {
+      (window as any).__TEST_MODE__ = true;
+    });
+
+    await landingPage.goto();
+    await apiMocker.mockChatSuccess(SIMPLE_RESPONSE);
+    await landingPage.submitFirstPrompt('Explain React');
+    await page.waitForURL(/\/t\/.+/);
+    await chatPage.waitForResponse();
+  });
+
+  test('should replace block content when clicking Replace', async ({ page }) => {
+    const originalText = await chatPage.getBlockText(0);
+
+    // Select block, switch to Edit mode
+    await chatPage.selectBlock(0);
+    await chatPage.clickEditMode();
+
+    // Clear and type new text
+    await chatPage.clearPrompt();
+    await chatPage.typePrompt('This is the new block content.');
+
+    // Click Replace
+    await chatPage.clickReplace();
+
+    // Verify block text changed
+    const newText = await chatPage.getBlockText(0);
+    expect(newText).toBe('This is the new block content.');
+    expect(newText).not.toBe(originalText);
+  });
+
+  test('should keep block selected after Replace', async () => {
+    await chatPage.selectBlock(0);
+    await chatPage.clickEditMode();
+
+    // Modify and replace
+    await chatPage.clearPrompt();
+    await chatPage.typePrompt('Modified content');
+    await chatPage.clickReplace();
+
+    // Block should still be selected
+    expect(await chatPage.isBlockSelected(0)).toBe(true);
+  });
+
+  test('should show Undo button after Replace (without selections)', async () => {
+    await chatPage.selectBlock(0);
+    await chatPage.clickEditMode();
+
+    // Modify and replace
+    await chatPage.clearPrompt();
+    await chatPage.typePrompt('Modified content');
+    await chatPage.clickReplace();
+
+    // Undo button should be visible
+    const undoButton = chatPage.getUndoButton(0);
+    await expect(undoButton).toBeVisible();
+  });
+
+  test('should restore original text when Undo is clicked', async () => {
+    const originalText = await chatPage.getBlockText(0);
+
+    await chatPage.selectBlock(0);
+    await chatPage.clickEditMode();
+
+    // Modify and replace
+    await chatPage.clearPrompt();
+    await chatPage.typePrompt('Modified content');
+    await chatPage.clickReplace();
+
+    // Verify text changed
+    expect(await chatPage.getBlockText(0)).toBe('Modified content');
+
+    // Click Undo
+    await chatPage.clickUndo(0);
+
+    // Verify original text restored
+    expect(await chatPage.getBlockText(0)).toBe(originalText);
+  });
+});
+
+test.describe('Direct Edit - Strikethrough', () => {
+  let landingPage: LandingPage;
+  let chatPage: ChatPage;
+  let apiMocker: ApiMocker;
+
+  test.beforeEach(async ({ page }) => {
+    landingPage = new LandingPage(page);
+    chatPage = new ChatPage(page);
+    apiMocker = new ApiMocker(page);
+
+    await page.addInitScript(() => {
+      (window as any).__TEST_MODE__ = true;
+    });
+
+    await landingPage.goto();
+    await apiMocker.mockChatSuccess(SIMPLE_RESPONSE);
+    await landingPage.submitFirstPrompt('Explain React');
+    await page.waitForURL(/\/t\/.+/);
+    await chatPage.waitForResponse();
+  });
+
+  test('should wrap text in strikethrough when select-all + backspace in Edit mode', async ({ page }) => {
+    await chatPage.selectBlock(0);
+    await chatPage.clickEditMode();
+
+    const originalText = await chatPage.getPromptValue();
+
+    // Select all and press backspace
+    await chatPage.selectAllAndPress('Backspace');
+
+    // Verify text is wrapped in strikethrough
+    const newText = await chatPage.getPromptValue();
+    expect(newText).toBe(`~~${originalText}~~`);
+  });
+
+  test('should render strikethrough in block after Replace', async ({ page }) => {
+    await chatPage.selectBlock(0);
+    await chatPage.clickEditMode();
+
+    // Select all and press backspace (creates strikethrough)
+    await chatPage.selectAllAndPress('Backspace');
+
+    // Click Replace
+    await chatPage.clickReplace();
+
+    // Verify block contains <del> element (strikethrough)
+    const block = chatPage.getBlock(0);
+    const delElement = block.locator('del');
+    await expect(delElement).toBeVisible();
+  });
+});
+
+test.describe('Direct Edit - Edge Cases', () => {
+  let landingPage: LandingPage;
+  let chatPage: ChatPage;
+  let apiMocker: ApiMocker;
+
+  test.beforeEach(async ({ page }) => {
+    landingPage = new LandingPage(page);
+    chatPage = new ChatPage(page);
+    apiMocker = new ApiMocker(page);
+
+    await page.addInitScript(() => {
+      (window as any).__TEST_MODE__ = true;
+    });
+
+    await landingPage.goto();
+    await apiMocker.mockChatSuccess(SIMPLE_RESPONSE);
+    await landingPage.submitFirstPrompt('Explain React');
+    await page.waitForURL(/\/t\/.+/);
+    await chatPage.waitForResponse();
+  });
+
+  test('should reset to Ask mode when switching to a different block', async ({ page }) => {
+    // Need multiple blocks for this test
+    await apiMocker.mockChatSuccess({
+      text: `## First Block
+
+This is the second block.`,
+    });
+    await chatPage.submitPrompt('Give me more');
+    await chatPage.waitForResponse();
+
+    // Select first new block and switch to Edit mode
+    await chatPage.selectBlock(1);
+    await chatPage.clickEditMode();
+    expect(await chatPage.isInEditMode()).toBe(true);
+
+    // Select a different block
+    await chatPage.selectBlock(2);
+
+    // Should reset to Ask mode
+    expect(await chatPage.isInAskMode()).toBe(true);
+  });
+
+  test('should not replace when composer is empty', async () => {
+    const originalText = await chatPage.getBlockText(0);
+
+    await chatPage.selectBlock(0);
+    await chatPage.clickEditMode();
+
+    // Clear the prompt completely
+    await chatPage.clearPrompt();
+
+    // Click Replace (should do nothing)
+    await chatPage.clickReplace();
+
+    // Block text should be unchanged
+    expect(await chatPage.getBlockText(0)).toBe(originalText);
+  });
+});

--- a/e2e/page-objects/ChatPage.ts
+++ b/e2e/page-objects/ChatPage.ts
@@ -20,14 +20,17 @@ export class ChatPage {
   readonly assistantMessages: Locator;
   readonly blocks: Locator;
 
+  readonly modeToggle: Locator;
+
   constructor(page: Page) {
     this.page = page;
     this.composer = page.locator('form.composer');
     this.promptInput = this.composer.locator('div#prompt, [role="textbox"]');
     this.sendButton = this.composer.locator('button[type="submit"]');
-    // Block controls wrapper (div with mt-2 class that contains the action badges)
+    // Block controls wrapper (div that contains the action badges)
     // Note: BlockControls uses Badge components which render as <div> elements, not buttons
-    this.blockControls = this.composer.locator('.mt-2').filter({ hasText: /Translate|ELI5|Example|Expand/ });
+    this.blockControls = this.composer.locator('div').filter({ hasText: /Translate|ELI5|Example|Expand/ }).first();
+    this.modeToggle = this.composer.locator('div').filter({ has: page.locator('button', { hasText: 'Ask' }) }).filter({ has: page.locator('button', { hasText: 'Edit' }) }).first();
     this.messages = page.locator('.user-message, .assistant-message');
     this.userMessages = page.locator('.user-message');
     this.assistantMessages = page.locator('.assistant-message');
@@ -503,5 +506,96 @@ export class ChatPage {
     await cancelButton.click();
     // Wait for dialog to close
     await this.page.waitForTimeout(100);
+  }
+
+  // ==================== Direct Edit Mode Methods ====================
+
+  /**
+   * Check if Ask/Edit toggle is visible
+   */
+  async isModeToggleVisible(): Promise<boolean> {
+    return await this.modeToggle.isVisible();
+  }
+
+  /**
+   * Click Ask mode in toggle
+   */
+  async clickAskMode(): Promise<void> {
+    const askButton = this.modeToggle.locator('button', { hasText: 'Ask' });
+    await askButton.click();
+    await this.page.waitForTimeout(100);
+  }
+
+  /**
+   * Click Edit mode in toggle
+   */
+  async clickEditMode(): Promise<void> {
+    const editButton = this.modeToggle.locator('button', { hasText: 'Edit' });
+    await editButton.click();
+    await this.page.waitForTimeout(100);
+  }
+
+  /**
+   * Check if currently in Edit mode (Edit button is active)
+   */
+  async isInEditMode(): Promise<boolean> {
+    const editButton = this.modeToggle.locator('button', { hasText: 'Edit' });
+    const className = await editButton.getAttribute('class');
+    // Active button has bg-background class
+    return className?.includes('bg-background') || false;
+  }
+
+  /**
+   * Check if currently in Ask mode (Ask button is active)
+   */
+  async isInAskMode(): Promise<boolean> {
+    const askButton = this.modeToggle.locator('button', { hasText: 'Ask' });
+    const className = await askButton.getAttribute('class');
+    return className?.includes('bg-background') || false;
+  }
+
+  /**
+   * Get submit button text (Send vs Replace)
+   */
+  async getSubmitButtonText(): Promise<string> {
+    return await this.sendButton.innerText();
+  }
+
+  /**
+   * Click Replace button (alias for sendButton.click in edit mode)
+   */
+  async clickReplace(): Promise<void> {
+    await this.sendButton.click();
+    await this.page.waitForTimeout(100);
+  }
+
+  /**
+   * Clear the prompt input
+   */
+  async clearPrompt(): Promise<void> {
+    await this.promptInput.evaluate((el) => {
+      el.textContent = '';
+      el.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    });
+  }
+
+  /**
+   * Select all text in composer and press a key
+   */
+  async selectAllAndPress(key: string): Promise<void> {
+    await this.promptInput.click();
+    // Select all with Cmd/Ctrl+A
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+    await this.page.keyboard.press(`${modifier}+a`);
+    await this.page.keyboard.press(key);
+    await this.page.waitForTimeout(100);
+  }
+
+  /**
+   * Get the undo button for a block (standalone, not in selection chips)
+   */
+  getUndoButton(blockIndex: number): Locator {
+    const block = this.getBlock(blockIndex);
+    return block.locator('.chip-undo');
   }
 }

--- a/hooks/useComposer.ts
+++ b/hooks/useComposer.ts
@@ -18,6 +18,7 @@ import { getLastAssistantResponseId } from '@/lib/state';
 import { getErrorMessage } from '@/lib/utils/errorHandling';
 import { useStreaming } from './useStreaming';
 import type { BlockAction } from '@/types/api';
+import type { ComposerMode } from '@/types/state/ui';
 import { idFactory } from '@/lib/utils/idFactory';
 
 export interface UseComposerReturn {
@@ -28,14 +29,20 @@ export interface UseComposerReturn {
   error: string | null;
   clearPrompt: () => void;
   handleBlockAction: (action: BlockAction) => Promise<void>;
+  // Edit mode support
+  composerMode: ComposerMode;
+  setComposerMode: (mode: ComposerMode) => void;
+  populateWithBlockText: () => void;
 }
 
 export function useComposer(): UseComposerReturn {
   const [prompt, setPrompt] = useState('');
+  const [composerMode, setComposerMode] = useState<ComposerMode>('chat');
 
   // Store state
   const settings = useStore((state) => state.settings);
   const selectedBlockId = useStore((state) => state.selectedBlockId);
+  const rewriteBlock = useStore((state) => state.rewriteBlock);
 
   // Track previous selectedBlockId to detect block switches
   const prevSelectedBlockIdRef = useRef(selectedBlockId);
@@ -51,6 +58,17 @@ export function useComposer(): UseComposerReturn {
     }
 
     prevSelectedBlockIdRef.current = curr;
+  }, [selectedBlockId]);
+
+  // Manage composer mode based on block selection
+  useEffect(() => {
+    if (selectedBlockId) {
+      // Default to 'ask' when block is selected
+      setComposerMode('ask');
+    } else {
+      // Return to 'chat' when no block is selected
+      setComposerMode('chat');
+    }
   }, [selectedBlockId]);
 
   const selectedBlock = useStore(selectSelectedBlock);
@@ -78,6 +96,27 @@ export function useComposer(): UseComposerReturn {
     setPrompt('');
     setError(null);
   }, [setError]);
+
+  /**
+   * Populate composer with selected block's text (for edit mode)
+   */
+  const populateWithBlockText = useCallback(() => {
+    if (selectedBlock) {
+      setPrompt(selectedBlock.text);
+    }
+  }, [selectedBlock]);
+
+  /**
+   * Handle direct edit submission (replace block text)
+   * No API call - text comes directly from user input
+   * Keeps block selected so user can continue editing or undo
+   */
+  const handleDirectEdit = useCallback(() => {
+    if (!selectedBlockId || !prompt.trim()) return;
+
+    rewriteBlock(selectedBlockId, prompt.trim());
+    // Don't clear selection - keep block selected for further edits or undo
+  }, [selectedBlockId, prompt, rewriteBlock]);
 
   /**
    * Handle block action (ELI5, Translate, Expand, Example, Ask)
@@ -144,7 +183,13 @@ export function useComposer(): UseComposerReturn {
       if (isSubmitting) return;
       if (!trimmedPrompt) return;
 
-      // BLOCK MODE: Result goes to composer when a block is selected
+      // EDIT MODE: Direct block replacement (no API call)
+      if (composerMode === 'edit' && selectedBlockId) {
+        handleDirectEdit();
+        return;
+      }
+
+      // ASK MODE: Result goes to composer when a block is selected
       if (selectedBlockId && contentForTransform.length > 0) {
         await handleBlockAction('ask');
         return;
@@ -223,7 +268,9 @@ export function useComposer(): UseComposerReturn {
       selectedBlockId,
       contentForTransform,
       mode,
+      composerMode,
       handleBlockAction,
+      handleDirectEdit,
       createThread,
       setMode,
       addUserMessage,
@@ -244,5 +291,9 @@ export function useComposer(): UseComposerReturn {
     error,
     clearPrompt,
     handleBlockAction,
+    // Edit mode support
+    composerMode,
+    setComposerMode,
+    populateWithBlockText,
   };
 }

--- a/lib/rendering/markdown.ts
+++ b/lib/rendering/markdown.ts
@@ -4,7 +4,7 @@
  */
 
 export interface MarkdownSegment {
-  type: 'text' | 'bold' | 'italic' | 'link' | 'inline-math' | 'block-math' | 'break';
+  type: 'text' | 'bold' | 'italic' | 'strikethrough' | 'link' | 'inline-math' | 'block-math' | 'break';
   content: string;
   /** URL for link segments */
   href?: string;
@@ -64,7 +64,7 @@ export function parseInlineMarkdown(text: string): MarkdownSegment[] {
  * Token for inline markdown parsing
  */
 interface InlineToken {
-  type: 'text' | 'bold' | 'italic' | 'link';
+  type: 'text' | 'bold' | 'italic' | 'strikethrough' | 'link';
   content: string;
   href?: string;
   start: number;
@@ -114,6 +114,22 @@ function parseInlineFormatting(text: string): MarkdownSegment[] {
       if (!overlaps) {
         tokens.push({
           type: 'bold',
+          content: match[1],
+          start: match.index,
+          end: match.index + match[0].length,
+        });
+      }
+    }
+
+    // Find strikethrough: ~~text~~
+    const strikethroughRegex = /~~(.+?)~~/g;
+    while ((match = strikethroughRegex.exec(part)) !== null) {
+      const overlaps = tokens.some(
+        (t) => match!.index < t.end && match!.index + match![0].length > t.start
+      );
+      if (!overlaps) {
+        tokens.push({
+          type: 'strikethrough',
           content: match[1],
           start: match.index,
           end: match.index + match[0].length,
@@ -244,6 +260,7 @@ export function stripMarkdown(text: string): string {
     .replace(/\\\(([\s\S]*?)\\\)/g, (_, tex) => tex) // Inline math
     .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // Links - keep text, remove URL
     .replace(/\*\*(.*?)\*\*/g, '$1') // Bold
+    .replace(/~~(.*?)~~/g, '$1') // Strikethrough
     .replace(/(?<!\*)\*(?!\*)([^*]+?)(?<!\*)\*(?!\*)/g, '$1') // Italic (asterisk)
     .replace(/_([^_]+?)_/g, '$1') // Italic (underscore)
     .replace(/\n/g, ' '); // Line breaks

--- a/types/state/ui.ts
+++ b/types/state/ui.ts
@@ -8,7 +8,10 @@
  */
 
 export type AppMode = 'landing' | 'thread';
-export type ComposerMode = 'chat' | 'block';
+export type ComposerMode = 'chat' | 'ask' | 'edit';
+// - 'chat': No block selected, normal chat mode
+// - 'ask': Block selected, asking about it (default when block selected)
+// - 'edit': Block selected, directly editing the block
 
 export interface UIState {
   mode: AppMode;


### PR DESCRIPTION
## Summary

- Add **Ask/Edit toggle** to composer when a block is selected
- **Ask mode** (default): existing behavior - ask questions about the block
- **Edit mode**: composer fills with block text, user edits directly, Replace button updates block
- Add **strikethrough support**: select all + backspace wraps text in `~~strikethrough~~` instead of deleting
- Block stays selected after Replace for continued editing or undo

## Changes

- `types/state/ui.ts`: Update ComposerMode to `'chat' | 'ask' | 'edit'`
- `hooks/useComposer.ts`: Add edit mode logic, `handleDirectEdit`, `populateWithBlockText`
- `components/composer/BlockModeToggle.tsx`: New toggle component
- `components/composer/Composer.tsx`: Show toggle, change button to "Replace" in edit mode
- `components/composer/PromptInput.tsx`: Edit mode placeholder, strikethrough on select-all + delete
- `components/chat/DocBlock.tsx`: Show standalone Undo button when rewritten without selections
- `lib/rendering/markdown.ts`: Add `~~strikethrough~~` parsing
- `components/content/BlockContent.tsx`: Render strikethrough with `<del>` tag

## Test plan

- [ ] Select a block → verify Ask/Edit toggle appears
- [ ] Click Edit → verify composer fills with block text
- [ ] Modify text and click Replace → verify block updates
- [ ] Verify Undo button appears after Replace
- [ ] Click Undo → verify original text restored
- [ ] In edit mode, Cmd+A then Backspace → verify strikethrough wraps text
- [ ] Replace with strikethrough text → verify renders with line-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)