### PR TITLE
feat: add Obsidian vault export destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ If you want a longer write-up, check out my blog post: [ChatGPT, the Slot Machin
 - **Direct block editing**: toggle between Ask and Edit modes — Ask sends to AI, Edit lets you rewrite text directly
 - **Text selection → focused rewriting**: highlight parts of follow-ups and request rewrites with that emphasis
 - **Cards**: collect blocks into cards as visual anchors, then export to your PKM system
+- **Obsidian export**: save exports directly to an Obsidian vault folder on disk (or use browser download)
 - **Response language**: set preferred response language (English or Chinese) for AI outputs
 - **Multi-user auth**: Supabase Auth with Row Level Security for data isolation
 - **Local-first or database-backed**: works with localStorage, or with Supabase for persistence
@@ -133,13 +134,14 @@ npm run start
 
 Access settings via the gear icon in the sidebar:
 
-| Setting             | Options                           | Default  |
-|---------------------|-----------------------------------|----------|
-| Model               | gpt-5.2, gpt-5-mini              | gpt-5.2  |
-| Reasoning Effort    | none, low, medium, high           | none     |
-| Web Search          | on/off                            | off      |
-| Response Language   | English, Chinese                  | English  |
-| Translate Language  | English, Chinese, Spanish, French | Chinese  |
+| Setting              | Options                           | Default  |
+|----------------------|-----------------------------------|----------|
+| Model                | gpt-5.2, gpt-5-mini              | gpt-5.2  |
+| Reasoning Effort     | none, low, medium, high           | none     |
+| Web Search           | on/off                            | off      |
+| Response Language    | English, Chinese                  | English  |
+| Translate Language   | English, Chinese, Spanish, French | Chinese  |
+| Export Destination   | Local (browser), Obsidian (vault) | Local    |
 
 
 ## Usage
@@ -191,6 +193,7 @@ Each card has its own **export** and **clear** actions.
 
 - If there are **no cards**, export defaults to the whole thread (all messages between user and LLM).
 - If there **are cards**, export defaults to merging all cards into a single `.md`.
+- **Export destination**: choose between browser download (Local) or saving directly to an Obsidian vault. When Obsidian is selected, files are written to a `Coo/` subfolder inside your vault path.
 
 ## Project Structure
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from 'next';
+import { Toaster } from 'sonner';
 import { ErrorBoundary } from '@/components/error/ErrorBoundary';
 import './globals.css';
 
@@ -23,6 +24,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
+        <Toaster position="bottom-right" />
         <ErrorBoundary>{children}</ErrorBoundary>
       </body>
     </html>

--- a/components/chat/CardControls.tsx
+++ b/components/chat/CardControls.tsx
@@ -2,12 +2,13 @@
 
 import { useState } from 'react';
 import { X, Download } from 'lucide-react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { useStore, selectActiveThread } from '@/lib/store/useStore';
 import {
   blocksToCardMarkdown,
   generateCardFilename,
-  downloadMarkdown,
+  exportMarkdown,
 } from '@/lib/export';
 import { ExportCardDialog } from './ExportCardDialog';
 import { Block } from '@/types/block';
@@ -24,6 +25,7 @@ interface CardControlsProps {
  */
 export function CardControls({ cardId, cardBlocks, onRemove }: CardControlsProps) {
   const activeThread = useStore(selectActiveThread);
+  const settings = useStore((state) => state.settings);
   const [dialogOpen, setDialogOpen] = useState(false);
 
   const blockCount = cardBlocks.length;
@@ -31,7 +33,7 @@ export function CardControls({ cardId, cardBlocks, onRemove }: CardControlsProps
   /**
    * Export card blocks as markdown
    */
-  const handleExportCard = (title: string) => {
+  const handleExportCard = async (title: string) => {
     if (!activeThread) return;
 
     const markdown = blocksToCardMarkdown(
@@ -40,7 +42,14 @@ export function CardControls({ cardId, cardBlocks, onRemove }: CardControlsProps
       cardBlocks
     );
     const filename = generateCardFilename(title);
-    downloadMarkdown(markdown, filename);
+    const result = await exportMarkdown(markdown, filename, settings);
+    if (settings.exportDestination === 'obsidian') {
+      if (result.success) {
+        toast.success('Saved to Obsidian vault');
+      } else {
+        toast.error(`Failed: ${result.error}`);
+      }
+    }
     setDialogOpen(false);
   };
 

--- a/components/chat/ExportButton.tsx
+++ b/components/chat/ExportButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Download, ChevronDown, FileText } from 'lucide-react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -22,7 +23,7 @@ import {
   generateExportFilename,
   blocksToCardMarkdown,
   generateCardFilename,
-  downloadMarkdown,
+  exportMarkdown,
 } from '@/lib/export';
 import { ExportCardDialog } from './ExportCardDialog';
 
@@ -37,6 +38,7 @@ export function ExportButton() {
   const allBlocks = useStore(useShallow(selectActiveThreadBlocks));
   const cards = useStore(selectCards);
   const allCardBlocks = useStore(useShallow(selectAllCardBlocks));
+  const settings = useStore((state) => state.settings);
 
   const [dialogOpen, setDialogOpen] = useState(false);
 
@@ -44,9 +46,21 @@ export function ExportButton() {
   const hasCards = cards.length > 0;
 
   /**
+   * Handle the result of an export (show toast for Obsidian)
+   */
+  const handleExportResult = (result: { success: boolean; error?: string }) => {
+    if (settings.exportDestination !== 'obsidian') return;
+    if (result.success) {
+      toast.success('Saved to Obsidian vault');
+    } else {
+      toast.error(`Failed: ${result.error}`);
+    }
+  };
+
+  /**
    * Export entire thread as markdown
    */
-  const handleExportThread = () => {
+  const handleExportThread = async () => {
     if (!activeThread) return;
 
     const markdown = threadToMarkdown(
@@ -55,13 +69,14 @@ export function ExportButton() {
       allBlocks
     );
     const filename = generateExportFilename(activeThread.title);
-    downloadMarkdown(markdown, filename);
+    const result = await exportMarkdown(markdown, filename, settings);
+    handleExportResult(result);
   };
 
   /**
    * Export all cards as a combined markdown file
    */
-  const handleExportAllCards = (title: string) => {
+  const handleExportAllCards = async (title: string) => {
     if (!activeThread) return;
 
     const markdown = blocksToCardMarkdown(
@@ -70,7 +85,8 @@ export function ExportButton() {
       allCardBlocks
     );
     const filename = generateCardFilename(title);
-    downloadMarkdown(markdown, filename);
+    const result = await exportMarkdown(markdown, filename, settings);
+    handleExportResult(result);
   };
 
   // Block count for display

--- a/components/settings/SettingsForm.tsx
+++ b/components/settings/SettingsForm.tsx
@@ -6,6 +6,7 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { useStore } from "@/lib/store/useStore";
 import { signOut } from "@/lib/supabase/auth";
@@ -19,6 +20,7 @@ import type {
   ReasoningEffort,
   ResponseLanguage,
   TranslateLanguage,
+  ExportDestination,
 } from "@/types/settings";
 
 const MODEL_OPTIONS: {
@@ -78,6 +80,12 @@ export function SettingsForm() {
   );
   const updateTranslateLanguage = useStore(
     (state) => state.updateTranslateLanguage,
+  );
+  const updateExportDestination = useStore(
+    (state) => state.updateExportDestination,
+  );
+  const updateObsidianVaultPath = useStore(
+    (state) => state.updateObsidianVaultPath,
   );
   const resetSettings = useStore((state) => state.resetSettings);
   const resetStore = useStore((state) => state.reset);
@@ -261,6 +269,53 @@ export function SettingsForm() {
           checked={settings.webSearchEnabled}
           onCheckedChange={updateWebSearchEnabled}
         />
+      </div>
+
+      <Separator />
+
+      {/* Export Destination */}
+      <div className="space-y-3">
+        <Label className="text-sm font-semibold">Export Destination</Label>
+        <RadioGroup
+          value={settings.exportDestination}
+          onValueChange={(value) =>
+            updateExportDestination(value as ExportDestination)
+          }
+          className="grid gap-2"
+        >
+          <div className="flex items-center space-x-3">
+            <RadioGroupItem value="local" id="export-local" />
+            <Label
+              htmlFor="export-local"
+              className="flex flex-col cursor-pointer font-normal"
+            >
+              <span>Local</span>
+              <span className="text-xs text-muted-foreground">
+                Browser download
+              </span>
+            </Label>
+          </div>
+          <div className="flex items-center space-x-3">
+            <RadioGroupItem value="obsidian" id="export-obsidian" />
+            <Label
+              htmlFor="export-obsidian"
+              className="flex flex-col cursor-pointer font-normal"
+            >
+              <span>Obsidian</span>
+              <span className="text-xs text-muted-foreground">
+                Save to vault folder
+              </span>
+            </Label>
+          </div>
+        </RadioGroup>
+        {settings.exportDestination === "obsidian" && (
+          <Input
+            value={settings.obsidianVaultPath ?? ""}
+            onChange={(e) => updateObsidianVaultPath(e.target.value)}
+            placeholder="/Users/you/ObsidianVault"
+            className="mt-2"
+          />
+        )}
       </div>
 
       <Separator />

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -288,7 +288,24 @@ Response with **markdown** preserved.
 Key files:
 - `lib/export/markdownExport.ts` — Pure function `threadToMarkdown(thread, messages, blocks)`
 - `lib/export/download.ts` — Browser download utility `downloadMarkdown(content, filename)`
+- `lib/export/exportMarkdown.ts` — Unified export dispatcher (local download or Obsidian vault)
+- `lib/export/saveToVault.ts` — Server action to save markdown to an Obsidian vault
 - `lib/export/index.ts` — Re-exports
+
+### Export Destination Setting
+
+Users can choose where exports are saved via Settings:
+
+- **Local** (default) — Browser file download
+- **Obsidian** — Saves markdown directly to `{vaultPath}/Coo/{filename}` on disk
+
+When Obsidian is selected, a text input appears for the vault path. The `Coo/` subfolder is auto-created if missing. Toast notifications (via `sonner`) report success or errors for vault exports.
+
+Key files:
+- `types/settings.ts` — `ExportDestination` type, `exportDestination` and `obsidianVaultPath` in `Settings`
+- `lib/state/settings.ts` — `updateExportDestination()`, `updateObsidianVaultPath()` pure functions
+- `lib/store/slices/settingsSlice.ts` — Zustand actions
+- `components/settings/SettingsForm.tsx` — Export destination radio + vault path input
 
 ### Offline Mode
 

--- a/e2e/mock/card-mode.spec.ts
+++ b/e2e/mock/card-mode.spec.ts
@@ -402,8 +402,7 @@ test.describe('Card Mode - Export Integration', () => {
     // Verify markdown frontmatter structure
     expect(content).toMatch(/^---\n/);
     expect(content).toContain('title: "My Test Card"');
-    expect(content).toContain('type: card');
-    expect(content).toMatch(/exported: \d{4}-\d{2}-\d{2}T/);
+    expect(content).toMatch(/created: \d{4}-\d{2}-\d{2}\n/);
     expect(content).toMatch(/---\n/);
 
     // Verify content includes the block text

--- a/lib/export/exportMarkdown.ts
+++ b/lib/export/exportMarkdown.ts
@@ -1,0 +1,33 @@
+import type { Settings } from "@/types/settings";
+import { downloadMarkdown } from "./download";
+import { saveToVault, type SaveToVaultResult } from "./saveToVault";
+
+export interface ExportResult {
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Unified export function that dispatches to the configured destination.
+ *
+ * - `local`: triggers a browser download (always succeeds)
+ * - `obsidian`: saves to vault via server action, returns result for toast
+ */
+export async function exportMarkdown(
+  content: string,
+  filename: string,
+  settings: Settings
+): Promise<ExportResult> {
+  if (settings.exportDestination === "obsidian") {
+    const result: SaveToVaultResult = await saveToVault(
+      content,
+      filename,
+      settings.obsidianVaultPath
+    );
+    return result;
+  }
+
+  // Local download (browser-side, always succeeds)
+  downloadMarkdown(content, filename);
+  return { success: true };
+}

--- a/lib/export/index.ts
+++ b/lib/export/index.ts
@@ -11,3 +11,6 @@ export {
 } from './markdownExport';
 
 export { downloadMarkdown } from './download';
+
+export { saveToVault } from './saveToVault';
+export { exportMarkdown } from './exportMarkdown';

--- a/lib/export/markdownExport.ts
+++ b/lib/export/markdownExport.ts
@@ -19,13 +19,13 @@ export const threadToMarkdown = (
   messages: Message[],
   blocks: Block[]
 ): string => {
-  const exportDate = new Date().toISOString();
+  const createdDate = new Date().toISOString().split('T')[0];
 
   // Build YAML frontmatter
   const frontmatter = [
     '---',
     `title: "${escapeYamlString(thread.title)}"`,
-    `exported: ${exportDate}`,
+    `created: ${createdDate}`,
     '---',
     '',
   ].join('\n');
@@ -101,15 +101,14 @@ export const blocksToCardMarkdown = (
   originalQuestion: string,
   blocks: Block[]
 ): string => {
-  const exportDate = new Date().toISOString();
+  const createdDate = new Date().toISOString().split('T')[0];
 
   // Build YAML frontmatter
   const frontmatter = [
     '---',
     `title: "${escapeYamlString(title)}"`,
     `original question: "${escapeYamlString(originalQuestion)}"`,
-    `exported: ${exportDate}`,
-    `type: card`,
+    `created: ${createdDate}`,
     '---',
     '',
   ].join('\n');

--- a/lib/export/saveToVault.ts
+++ b/lib/export/saveToVault.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { mkdir, writeFile, stat } from "fs/promises";
+import { join } from "path";
+
+export interface SaveToVaultResult {
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Save markdown content to an Obsidian vault folder.
+ * Creates a `Coo/` subfolder inside the vault if it doesn't exist.
+ *
+ * @param content - Markdown content to save
+ * @param filename - Filename (should end in .md)
+ * @param vaultPath - Absolute path to the Obsidian vault root
+ */
+export async function saveToVault(
+  content: string,
+  filename: string,
+  vaultPath: string
+): Promise<SaveToVaultResult> {
+  if (!vaultPath.trim()) {
+    return { success: false, error: "Vault path is empty" };
+  }
+
+  try {
+    // Validate vault path exists
+    const vaultStat = await stat(vaultPath);
+    if (!vaultStat.isDirectory()) {
+      return { success: false, error: "Vault path is not a directory" };
+    }
+
+    // Create Coo/ subfolder if needed
+    const cooDir = join(vaultPath, "Coo");
+    await mkdir(cooDir, { recursive: true });
+
+    // Write the file
+    const filePath = join(cooDir, filename);
+    await writeFile(filePath, content, "utf-8");
+
+    return { success: true };
+  } catch (err) {
+    if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+      return { success: false, error: "Vault path does not exist" };
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return { success: false, error: message };
+  }
+}

--- a/lib/state/settings.ts
+++ b/lib/state/settings.ts
@@ -10,6 +10,7 @@ import type {
   ReasoningEffort,
   ResponseLanguage,
   TranslateLanguage,
+  ExportDestination,
 } from "@/types/settings";
 import {
   DEFAULT_SETTINGS,
@@ -84,6 +85,26 @@ export const updateTranslateLanguage = (
   translateLanguage: TranslateLanguage,
 ): Settings => {
   return { ...settings, translateLanguage };
+};
+
+/**
+ * Update the export destination setting
+ */
+export const updateExportDestination = (
+  settings: Settings,
+  exportDestination: ExportDestination,
+): Settings => {
+  return { ...settings, exportDestination };
+};
+
+/**
+ * Update the Obsidian vault path setting
+ */
+export const updateObsidianVaultPath = (
+  settings: Settings,
+  obsidianVaultPath: string,
+): Settings => {
+  return { ...settings, obsidianVaultPath };
 };
 
 /**

--- a/lib/store/slices/settingsSlice.ts
+++ b/lib/store/slices/settingsSlice.ts
@@ -11,6 +11,7 @@ import type {
   ReasoningEffort,
   ResponseLanguage,
   TranslateLanguage,
+  ExportDestination,
 } from "@/types/settings";
 
 export interface SettingsSlice {
@@ -23,6 +24,8 @@ export interface SettingsSlice {
   updateWebSearchEnabled: (enabled: boolean) => void;
   updateResponseLanguage: (language: ResponseLanguage) => void;
   updateTranslateLanguage: (language: TranslateLanguage) => void;
+  updateExportDestination: (destination: ExportDestination) => void;
+  updateObsidianVaultPath: (path: string) => void;
   resetSettings: () => void;
 }
 
@@ -67,6 +70,19 @@ export const settingsSlice: StateCreator<
       get().settings,
       language,
     );
+    set({ settings: updated });
+  },
+
+  updateExportDestination: (destination) => {
+    const updated = settingsFns.updateExportDestination(
+      get().settings,
+      destination,
+    );
+    set({ settings: updated });
+  },
+
+  updateObsidianVaultPath: (path) => {
+    const updated = settingsFns.updateObsidianVaultPath(get().settings, path);
     set({ settings: updated });
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "openai": "^6.16.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",
         "zustand": "^5.0.10"
@@ -9171,6 +9172,16 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "openai": "^6.16.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
     "zustand": "^5.0.10"

--- a/tests/mocks/store.ts
+++ b/tests/mocks/store.ts
@@ -39,12 +39,16 @@ interface MockStoreState {
     responseLanguage: string;
     translateLanguage: string;
     webSearchEnabled: boolean;
+    exportDestination: string;
+    obsidianVaultPath: string;
   };
   updateModel: ReturnType<typeof vi.fn>;
   updateReasoningEffort: ReturnType<typeof vi.fn>;
   updateResponseLanguage: ReturnType<typeof vi.fn>;
   updateTranslateLanguage: ReturnType<typeof vi.fn>;
   updateWebSearchEnabled: ReturnType<typeof vi.fn>;
+  updateExportDestination: ReturnType<typeof vi.fn>;
+  updateObsidianVaultPath: ReturnType<typeof vi.fn>;
   resetSettings: ReturnType<typeof vi.fn>;
 }
 
@@ -72,12 +76,16 @@ export function createMockStoreState(
       responseLanguage: "en",
       translateLanguage: "zh-TW",
       webSearchEnabled: false,
+      exportDestination: "local",
+      obsidianVaultPath: "",
     },
     updateModel: vi.fn(),
     updateReasoningEffort: vi.fn(),
     updateResponseLanguage: vi.fn(),
     updateTranslateLanguage: vi.fn(),
     updateWebSearchEnabled: vi.fn(),
+    updateExportDestination: vi.fn(),
+    updateObsidianVaultPath: vi.fn(),
     resetSettings: vi.fn(),
     ...overrides,
   };

--- a/tests/unit/components/chat/CardControls.test.tsx
+++ b/tests/unit/components/chat/CardControls.test.tsx
@@ -17,12 +17,12 @@ vi.mock('@/lib/store/useStore', () => ({
 
 const mockBlocksToCardMarkdown = vi.fn().mockReturnValue('# Card\ncontent');
 const mockGenerateCardFilename = vi.fn().mockReturnValue('card.md');
-const mockDownloadMarkdown = vi.fn();
+const mockExportMarkdown = vi.fn().mockResolvedValue({ success: true });
 
 vi.mock('@/lib/export', () => ({
   blocksToCardMarkdown: (...args: unknown[]) => mockBlocksToCardMarkdown(...args),
   generateCardFilename: (...args: unknown[]) => mockGenerateCardFilename(...args),
-  downloadMarkdown: (...args: unknown[]) => mockDownloadMarkdown(...args),
+  exportMarkdown: (...args: unknown[]) => mockExportMarkdown(...args),
 }));
 
 // Stub ExportCardDialog to capture props
@@ -101,6 +101,6 @@ describe('CardControls', () => {
       blocks,
     );
     expect(mockGenerateCardFilename).toHaveBeenCalledWith('Test Title');
-    expect(mockDownloadMarkdown).toHaveBeenCalledWith('# Card\ncontent', 'card.md');
+    expect(mockExportMarkdown).toHaveBeenCalledWith('# Card\ncontent', 'card.md', mockState.settings);
   });
 });

--- a/tests/unit/components/chat/ExportButton.test.tsx
+++ b/tests/unit/components/chat/ExportButton.test.tsx
@@ -32,14 +32,14 @@ const mockThreadToMarkdown = vi.fn().mockReturnValue('# Thread');
 const mockGenerateExportFilename = vi.fn().mockReturnValue('thread.md');
 const mockBlocksToCardMarkdown = vi.fn().mockReturnValue('# Cards');
 const mockGenerateCardFilename = vi.fn().mockReturnValue('cards.md');
-const mockDownloadMarkdown = vi.fn();
+const mockExportMarkdown = vi.fn().mockResolvedValue({ success: true });
 
 vi.mock('@/lib/export', () => ({
   threadToMarkdown: (...args: unknown[]) => mockThreadToMarkdown(...args),
   generateExportFilename: (...args: unknown[]) => mockGenerateExportFilename(...args),
   blocksToCardMarkdown: (...args: unknown[]) => mockBlocksToCardMarkdown(...args),
   generateCardFilename: (...args: unknown[]) => mockGenerateCardFilename(...args),
-  downloadMarkdown: (...args: unknown[]) => mockDownloadMarkdown(...args),
+  exportMarkdown: (...args: unknown[]) => mockExportMarkdown(...args),
 }));
 
 // Stub ExportCardDialog
@@ -104,7 +104,7 @@ describe('ExportButton', () => {
       fireEvent.click(screen.getByLabelText('Export thread'));
 
       expect(mockThreadToMarkdown).toHaveBeenCalled();
-      expect(mockDownloadMarkdown).toHaveBeenCalled();
+      expect(mockExportMarkdown).toHaveBeenCalled();
     });
   });
 
@@ -153,7 +153,7 @@ describe('ExportButton', () => {
       fireEvent.click(screen.getByText('Confirm'));
 
       expect(mockBlocksToCardMarkdown).toHaveBeenCalled();
-      expect(mockDownloadMarkdown).toHaveBeenCalled();
+      expect(mockExportMarkdown).toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/lib/export/markdownExport.test.ts
+++ b/tests/unit/lib/export/markdownExport.test.ts
@@ -66,7 +66,7 @@ describe('markdownExport', () => {
       // Check frontmatter
       expect(result).toMatch(/^---\n/);
       expect(result).toContain('title: "Test Thread"');
-      expect(result).toMatch(/exported: \d{4}-\d{2}-\d{2}T/);
+      expect(result).toMatch(/created: \d{4}-\d{2}-\d{2}\n/);
       expect(result).toMatch(/---\n## User/);
 
       // Check message structure
@@ -247,8 +247,8 @@ describe('markdownExport', () => {
       expect(result).toMatch(/^---\n/);
       expect(result).toContain('title: "My Card"');
       expect(result).toContain('original question: "What is React?"');
-      expect(result).toMatch(/exported: \d{4}-\d{2}-\d{2}T/);
-      expect(result).toContain('type: card');
+      expect(result).toMatch(/created: \d{4}-\d{2}-\d{2}\n/);
+      expect(result).not.toContain('type:');
       expect(result).not.toContain('blocks:');
 
       // Check content

--- a/tests/unit/lib/export/saveToVault.test.ts
+++ b/tests/unit/lib/export/saveToVault.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readFile, stat } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { saveToVault } from "@/lib/export/saveToVault";
+
+describe("saveToVault", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "coo-vault-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("should save a file to the Coo/ subfolder", async () => {
+    const result = await saveToVault("# Hello", "test.md", tempDir);
+    expect(result.success).toBe(true);
+
+    const content = await readFile(join(tempDir, "Coo", "test.md"), "utf-8");
+    expect(content).toBe("# Hello");
+  });
+
+  it("should create the Coo/ subfolder if missing", async () => {
+    await saveToVault("content", "file.md", tempDir);
+
+    const cooStat = await stat(join(tempDir, "Coo"));
+    expect(cooStat.isDirectory()).toBe(true);
+  });
+
+  it("should return error for empty vault path", async () => {
+    const result = await saveToVault("content", "file.md", "");
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Vault path is empty");
+  });
+
+  it("should return error for whitespace-only vault path", async () => {
+    const result = await saveToVault("content", "file.md", "   ");
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Vault path is empty");
+  });
+
+  it("should return error for nonexistent vault path", async () => {
+    const result = await saveToVault(
+      "content",
+      "file.md",
+      "/nonexistent/path/to/vault"
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Vault path does not exist");
+  });
+
+  it("should overwrite existing file", async () => {
+    await saveToVault("first", "test.md", tempDir);
+    await saveToVault("second", "test.md", tempDir);
+
+    const content = await readFile(join(tempDir, "Coo", "test.md"), "utf-8");
+    expect(content).toBe("second");
+  });
+});

--- a/tests/unit/lib/state/settings.test.ts
+++ b/tests/unit/lib/state/settings.test.ts
@@ -7,6 +7,8 @@ import {
   updateWebSearchEnabled,
   updateResponseLanguage,
   updateTranslateLanguage,
+  updateExportDestination,
+  updateObsidianVaultPath,
   resetSettings,
 } from "@/lib/state/settings";
 import { DEFAULT_SETTINGS } from "@/types/settings";
@@ -294,6 +296,76 @@ describe("Settings State Functions", () => {
     });
   });
 
+  describe("updateExportDestination", () => {
+    it("should update to obsidian", () => {
+      const settings = createInitialSettings();
+      const updated = updateExportDestination(settings, "obsidian");
+      expect(updated.exportDestination).toBe("obsidian");
+    });
+
+    it("should update to local", () => {
+      const settings: Settings = {
+        ...DEFAULT_SETTINGS,
+        exportDestination: "obsidian",
+      };
+      const updated = updateExportDestination(settings, "local");
+      expect(updated.exportDestination).toBe("local");
+    });
+
+    it("should maintain immutability", () => {
+      const settings = createInitialSettings();
+      const updated = updateExportDestination(settings, "obsidian");
+      expect(updated).not.toBe(settings);
+      expect(settings.exportDestination).toBe("local");
+    });
+
+    it("should preserve other settings", () => {
+      const settings: Settings = {
+        ...DEFAULT_SETTINGS,
+        model: "gpt-5.2",
+        webSearchEnabled: true,
+      };
+      const updated = updateExportDestination(settings, "obsidian");
+      expect(updated.model).toBe("gpt-5.2");
+      expect(updated.webSearchEnabled).toBe(true);
+    });
+  });
+
+  describe("updateObsidianVaultPath", () => {
+    it("should update vault path", () => {
+      const settings = createInitialSettings();
+      const updated = updateObsidianVaultPath(settings, "/Users/me/vault");
+      expect(updated.obsidianVaultPath).toBe("/Users/me/vault");
+    });
+
+    it("should clear vault path", () => {
+      const settings: Settings = {
+        ...DEFAULT_SETTINGS,
+        obsidianVaultPath: "/old/path",
+      };
+      const updated = updateObsidianVaultPath(settings, "");
+      expect(updated.obsidianVaultPath).toBe("");
+    });
+
+    it("should maintain immutability", () => {
+      const settings = createInitialSettings();
+      const updated = updateObsidianVaultPath(settings, "/new/path");
+      expect(updated).not.toBe(settings);
+      expect(settings.obsidianVaultPath).toBe("");
+    });
+
+    it("should preserve other settings", () => {
+      const settings: Settings = {
+        ...DEFAULT_SETTINGS,
+        exportDestination: "obsidian",
+        model: "gpt-5.2",
+      };
+      const updated = updateObsidianVaultPath(settings, "/vault");
+      expect(updated.exportDestination).toBe("obsidian");
+      expect(updated.model).toBe("gpt-5.2");
+    });
+  });
+
   describe("resetSettings", () => {
     it("should reset to default settings", () => {
       const reset = resetSettings();
@@ -305,6 +377,12 @@ describe("Settings State Functions", () => {
       const reset2 = resetSettings();
       expect(reset1).not.toBe(reset2);
       expect(reset1).toEqual(reset2);
+    });
+
+    it("should reset export settings to defaults", () => {
+      const reset = resetSettings();
+      expect(reset.exportDestination).toBe("local");
+      expect(reset.obsidianVaultPath).toBe("");
     });
   });
 });

--- a/tests/unit/lib/store/slices/settingsSlice.test.ts
+++ b/tests/unit/lib/store/slices/settingsSlice.test.ts
@@ -29,6 +29,8 @@ describe("settingsSlice", () => {
     expect(settings.webSearchEnabled).toBe(false);
     expect(settings.responseLanguage).toBe("en");
     expect(settings.translateLanguage).toBe("Chinese");
+    expect(settings.exportDestination).toBe("local");
+    expect(settings.obsidianVaultPath).toBe("");
   });
 
   describe("updateModel", () => {
@@ -97,6 +99,34 @@ describe("settingsSlice", () => {
     });
   });
 
+  describe("updateExportDestination", () => {
+    it("should update export destination to obsidian", () => {
+      useStore.getState().updateExportDestination("obsidian");
+      expect(useStore.getState().settings.exportDestination).toBe("obsidian");
+    });
+
+    it("should update export destination to local", () => {
+      useStore.getState().updateExportDestination("obsidian");
+      useStore.getState().updateExportDestination("local");
+      expect(useStore.getState().settings.exportDestination).toBe("local");
+    });
+  });
+
+  describe("updateObsidianVaultPath", () => {
+    it("should update vault path", () => {
+      useStore.getState().updateObsidianVaultPath("/Users/me/vault");
+      expect(useStore.getState().settings.obsidianVaultPath).toBe(
+        "/Users/me/vault",
+      );
+    });
+
+    it("should clear vault path", () => {
+      useStore.getState().updateObsidianVaultPath("/some/path");
+      useStore.getState().updateObsidianVaultPath("");
+      expect(useStore.getState().settings.obsidianVaultPath).toBe("");
+    });
+  });
+
   describe("resetSettings", () => {
     it("should reset all settings to defaults", () => {
       useStore.getState().updateModel("gpt-5.2");
@@ -104,6 +134,8 @@ describe("settingsSlice", () => {
       useStore.getState().updateWebSearchEnabled(true);
       useStore.getState().updateResponseLanguage("zh");
       useStore.getState().updateTranslateLanguage("French");
+      useStore.getState().updateExportDestination("obsidian");
+      useStore.getState().updateObsidianVaultPath("/vault");
 
       useStore.getState().resetSettings();
 
@@ -113,6 +145,8 @@ describe("settingsSlice", () => {
       expect(settings.webSearchEnabled).toBe(false);
       expect(settings.responseLanguage).toBe("en");
       expect(settings.translateLanguage).toBe("Chinese");
+      expect(settings.exportDestination).toBe("local");
+      expect(settings.obsidianVaultPath).toBe("");
     });
   });
 });

--- a/types/settings.ts
+++ b/types/settings.ts
@@ -61,6 +61,8 @@ export const getDefaultTranslateLanguage = (
   return "English";
 };
 
+export type ExportDestination = "local" | "obsidian";
+
 export interface Settings {
   systemPromptFile: SystemPromptFile;
   model: ModelType;
@@ -68,6 +70,8 @@ export interface Settings {
   webSearchEnabled: boolean;
   responseLanguage: ResponseLanguage;
   translateLanguage: TranslateLanguage;
+  exportDestination: ExportDestination;
+  obsidianVaultPath: string;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -77,4 +81,6 @@ export const DEFAULT_SETTINGS: Settings = {
   webSearchEnabled: false,
   responseLanguage: "en",
   translateLanguage: "Chinese",
+  exportDestination: "local",
+  obsidianVaultPath: "",
 };


### PR DESCRIPTION
## Summary
- Add export destination setting (Local / Obsidian) in Settings, with vault path input
- Create server action `saveToVault` that writes markdown to `{vault}/Coo/{filename}` on disk
- Unified `exportMarkdown` dispatcher routes to browser download or vault save based on setting
- Toast notifications (sonner) for Obsidian export success/error
- Simplify export frontmatter: `exported` → `created`, ISO → `yyyy-mm-dd`, remove `type` field

**14 files changed, ~240 lines of production code**

## Test plan
- [x] `npm run build` — passes, no type errors
- [x] `npm run lint` — passes
- [x] `npm run test` — 974/974 tests pass (new + updated tests for settings, slice, saveToVault, frontmatter)
- [x] Next.js MCP `get_errors` — no runtime errors
- [ ] Manual: Settings → Obsidian → enter vault path → export thread → verify file at `{vault}/Coo/{filename}.md`
- [ ] Manual: Switch to Local → export → browser download works
- [ ] Manual: Export cards with Obsidian → verify file saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)