### PR TITLE
fix: scope card selectors to active thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Coo brings locality to AI. It is a chatbot where you can **interact with LLM responses in context**.
 
+![](https://wenyi.blog/files/coo_ask.mp4)
+
 Instead of treating AI output as immutable chat bubbles, Coo breaks once-indivisible response into semantic blocks you can work with directly: expand, translate, simplify (ELI5), rewrite, and export as cards.
 
 ![Books are scattered around Shuji Terayama](https://blog.yitianshijie.net/wp-content/uploads/2017/07/fullsizeoutput_33bf.jpeg?w=550&h=862)

--- a/lib/store/useStore.ts
+++ b/lib/store/useStore.ts
@@ -95,16 +95,24 @@ export const selectContentForTransform = (state: StoreState): Block[] => {
 };
 
 /**
- * Select all cards
+ * Select cards for the active thread only
+ * Cards are scoped via messageId → thread's messages
  */
-export const selectCards = (state: StoreState): Card[] => state.cards;
+export const selectCards = (state: StoreState): Card[] => {
+  const activeThread = selectActiveThread(state);
+  if (!activeThread) return [];
+
+  const messageIds = new Set(activeThread.messages.map((m) => m.id));
+  return state.cards.filter((c) => messageIds.has(c.messageId));
+};
 
 /**
- * Select all blocks that are in any card (for export all cards)
+ * Select all blocks that are in any card for the active thread (for export all cards)
  * Returns blocks in document order, grouped by card
  */
 export const selectAllCardBlocks = (state: StoreState): Block[] => {
-  const allCardBlockIds = new Set(state.cards.flatMap((c) => c.blockIds));
+  const activeCards = selectCards(state);
+  const allCardBlockIds = new Set(activeCards.flatMap((c) => c.blockIds));
   return state.blocks.filter((b) => allCardBlockIds.has(b.id));
 };
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -96,8 +96,9 @@ export default defineConfig({
       ],
 
   /* Run your local dev server before starting the tests */
+  /* CI uses `npm start` (production server) since the app is pre-built; local uses `npm run dev` */
   webServer: {
-    command: 'npm run dev',
+    command: process.env.CI ? 'npm start' : 'npm run dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,

--- a/tests/unit/lib/store/selectors.test.ts
+++ b/tests/unit/lib/store/selectors.test.ts
@@ -71,11 +71,20 @@ describe("Store Selectors", () => {
   });
 
   describe("selectCards", () => {
-    it("should return all cards", () => {
+    it("should return cards belonging to the active thread", () => {
+      useStore.getState().createThread("thread-1");
+      useStore.getState().addAssistantMessage([
+        { text: "Block 1", type: "paragraph" },
+      ]);
+
+      const state = useStore.getState();
+      const messageId = state.threads.find((t) => t.id === "thread-1")!
+        .messages[0].id;
+
       const cards = [
         {
           id: "card-1",
-          messageId: "msg-1",
+          messageId,
           anchorBlockId: "b1",
           blockIds: ["b1"],
           createdAt: Date.now(),
@@ -83,8 +92,8 @@ describe("Store Selectors", () => {
       ];
       useStore.setState({ cards });
 
-      const state = useStore.getState() as StoreState;
-      expect(selectCards(state)).toEqual(cards);
+      const result = selectCards(useStore.getState() as StoreState);
+      expect(result).toEqual(cards);
     });
 
     it("should return empty array when no cards", () => {
@@ -102,13 +111,16 @@ describe("Store Selectors", () => {
         { text: "Block 3", type: "paragraph" },
       ]);
 
-      const blocks = useStore.getState().blocks;
+      const state = useStore.getState();
+      const blocks = state.blocks;
+      const messageId = state.threads.find((t) => t.id === "thread-1")!
+        .messages[0].id;
       // Manually set cards referencing block IDs
       useStore.setState({
         cards: [
           {
             id: "card-1",
-            messageId: "msg-1",
+            messageId,
             anchorBlockId: blocks[0].id,
             blockIds: [blocks[0].id, blocks[1].id],
             createdAt: Date.now(),
@@ -116,8 +128,8 @@ describe("Store Selectors", () => {
         ],
       });
 
-      const state = useStore.getState() as StoreState;
-      const cardBlocks = selectAllCardBlocks(state);
+      const updatedState = useStore.getState() as StoreState;
+      const cardBlocks = selectAllCardBlocks(updatedState);
       expect(cardBlocks).toHaveLength(2);
       expect(cardBlocks.map((b) => b.id)).toContain(blocks[0].id);
       expect(cardBlocks.map((b) => b.id)).toContain(blocks[1].id);


### PR DESCRIPTION
Cards were stored as a flat array and selectCards returned all cards regardless of which thread was active. When navigating from a thread with cards to one without, stale cards persisted, causing the export button to incorrectly show "Export Cards" and export data from the wrong thread.

Filter selectCards and selectAllCardBlocks by the active thread's message IDs so cards are automatically scoped to the current thread.