### PR TITLE
fix: make E2E tests resilient to dev server auth state

### DIFF
--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,6 +1,18 @@
 /**
  * Playwright Auth Setup
- * Logs in once and saves auth state for reuse in live tests
+ *
+ * Runs once before all test projects that depend on it.
+ * Handles two scenarios:
+ *
+ * 1. CI / test-mode server: NEXT_PUBLIC_TEST_MODE=true is baked into the build,
+ *    so useAuth() returns a fake user immediately. No login needed.
+ *
+ * 2. Local dev server reuse: The running dev server was started without
+ *    NEXT_PUBLIC_TEST_MODE, so real Supabase auth is active.
+ *    We log in with hardcoded test credentials to get a real session.
+ *
+ * In both cases, auth state (cookies + storage) is saved to a JSON file
+ * and shared with every test project via Playwright's storageState.
  */
 
 import { test as setup, expect } from '@playwright/test';
@@ -10,26 +22,35 @@ import path from 'path';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const authFile = path.join(__dirname, '../.artifacts/auth-state.json');
 
+const TEST_EMAIL = 'test@example.com';
+const TEST_PASSWORD = 'testpassword123';
+
 setup('authenticate', async ({ page }) => {
-  const email = process.env.TEST_USER_EMAIL || 'test@example.com';
-  const password = process.env.TEST_USER_PASSWORD || 'testpassword123';
+  // Navigate to home and check if auth is already satisfied (test mode)
+  await page.goto('/');
 
-  // Go to login page
-  await page.goto('/auth/login');
+  // The submit button is disabled when not authenticated.
+  // Wait briefly — in test mode this resolves instantly.
+  const submitButton = page.locator('button[type="submit"]');
+  const isReady = await submitButton
+    .isEnabled({ timeout: 3000 })
+    .catch(() => false);
 
-  // Fill in credentials
-  await page.getByLabel('Email').fill(email);
-  await page.getByLabel('Password').fill(password);
+  if (!isReady) {
+    // Dev server doesn't have test mode — log in with real credentials
+    await page.goto('/auth/login');
 
-  // Click sign in button
-  await page.getByRole('button', { name: /sign in/i }).click();
+    await page.getByLabel('Email').fill(TEST_EMAIL);
+    await page.getByLabel('Password').fill(TEST_PASSWORD);
+    await page.getByRole('button', { name: /sign in/i }).click();
 
-  // Wait for successful login - should redirect to home
-  await expect(page).toHaveURL('/');
+    // Wait for redirect to home after successful login
+    await expect(page).toHaveURL('/', { timeout: 10000 });
+  }
 
-  // Wait for auth state to settle
-  await expect(page.getByRole('button', { name: /new chat/i })).toBeVisible();
+  // Verify the app is usable (submit button enabled = authenticated)
+  await expect(submitButton).toBeEnabled({ timeout: 5000 });
 
-  // Save auth state for reuse
+  // Save auth state for reuse by all test projects
   await page.context().storageState({ path: authFile });
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -80,18 +80,27 @@ export default defineConfig({
         },
       ]
     : [
-        // Mock tests - no auth needed (test mode bypasses auth)
+        // Auth setup - logs in once (real login or test-mode passthrough)
+        {
+          name: 'auth-setup',
+          testMatch: /auth\.setup\.ts/,
+          testDir: './e2e',
+        },
+        // Mock tests - use saved auth state from setup
         {
           name: 'chromium',
-          use: { ...devices['Desktop Chrome'] },
+          use: { ...devices['Desktop Chrome'], storageState: authFile },
+          dependencies: ['auth-setup'],
         },
         {
           name: 'firefox',
-          use: { ...devices['Desktop Firefox'] },
+          use: { ...devices['Desktop Firefox'], storageState: authFile },
+          dependencies: ['auth-setup'],
         },
         {
           name: 'webkit',
-          use: { ...devices['Desktop Safari'] },
+          use: { ...devices['Desktop Safari'], storageState: authFile },
+          dependencies: ['auth-setup'],
         },
       ],
 


### PR DESCRIPTION
## Summary
- Mock E2E tests relied on `NEXT_PUBLIC_TEST_MODE` being baked into the dev server at startup. When Playwright reused an existing dev server started without that env var (`reuseExistingServer: true`), auth bypass didn't activate and the composer was disabled — causing all tests to fail.
- Added `auth-setup` as a dependency for all mock test projects. The setup auto-detects: if test mode is active (CI), it skips login; if not (local dev server), it logs in with hardcoded test credentials (`test@example.com`).
- This decouples test reliability from how the dev server was started.

## Test plan
- [x] All 256 E2E tests pass across Chromium, Firefox, WebKit
- [x] Auth setup passes in CI mode (`NEXT_PUBLIC_TEST_MODE=true`)
- [ ] Verify CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)