### PR TITLE
chore: rename models to gpt-5.4 and gpt-5.4-mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Access settings via the gear icon in the sidebar:
 
 | Setting              | Options                           | Default  |
 |----------------------|-----------------------------------|----------|
-| Model                | gpt-5.2, gpt-5-mini              | gpt-5.2  |
+| Model                | gpt-5.4, gpt-5.4-mini            | gpt-5.4  |
 | Reasoning Effort     | none, low, medium, high           | none     |
 | Web Search           | on/off                            | off      |
 | Response Language    | English, Chinese                  | English  |

--- a/components/settings/SettingsForm.tsx
+++ b/components/settings/SettingsForm.tsx
@@ -35,11 +35,11 @@ const MODEL_OPTIONS: {
   description: string;
 }[] = [
   {
-    value: "gpt-5-mini",
-    label: "GPT-5-mini",
+    value: "gpt-5.4-mini",
+    label: "GPT-5.4-mini",
     description: "Fast and efficient",
   },
-  { value: "gpt-5.2", label: "GPT-5.2", description: "Most capable" },
+  { value: "gpt-5.4", label: "GPT-5.4", description: "Most capable" },
 ];
 
 const REASONING_OPTIONS: { value: ReasoningEffort; label: string }[] = [

--- a/lib/config/openai.ts
+++ b/lib/config/openai.ts
@@ -4,7 +4,7 @@ export interface OpenAIModelConfig {
 
 export const getOpenAIModelConfig = (): OpenAIModelConfig => {
   return {
-    model: process.env.OPENAI_MODEL || "gpt-5-mini",
+    model: process.env.OPENAI_MODEL || "gpt-5.4-mini",
   };
 };
 
@@ -21,10 +21,10 @@ const MODEL_PRICING: Record<
   string,
   { input: number; cachedInput: number; output: number }
 > = {
-  "gpt-5.2": { input: 1.75, cachedInput: 0.175, output: 14.0 },
+  "gpt-5.4": { input: 1.75, cachedInput: 0.175, output: 14.0 },
   "gpt-5.1": { input: 1.25, cachedInput: 0.125, output: 10.0 },
   "gpt-5": { input: 1.25, cachedInput: 0.125, output: 10.0 },
-  "gpt-5-mini": { input: 0.25, cachedInput: 0.025, output: 2.0 },
+  "gpt-5.4-mini": { input: 0.25, cachedInput: 0.025, output: 2.0 },
   "gpt-5-nano": { input: 0.05, cachedInput: 0.005, output: 0.4 },
 };
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -34,9 +34,9 @@ export OPENAI_API_KEY=sk-...
 By default, tests use `gpt-4o-mini`. To test with a different model:
 
 ```bash
-export OPENAI_MODEL=gpt-5.2
+export OPENAI_MODEL=gpt-5.4
 # or
-export OPENAI_MODEL=gpt-5-mini
+export OPENAI_MODEL=gpt-5.4-mini
 # or
 export OPENAI_MODEL=gpt-5-nano
 ```

--- a/tests/unit/app/api/block-action/route.test.ts
+++ b/tests/unit/app/api/block-action/route.test.ts
@@ -218,11 +218,11 @@ describe("POST /api/block-action", () => {
         makeRequest({
           action: "eli5",
           blockText: "text",
-          settings: { model: "gpt-5.2" },
+          settings: { model: "gpt-5.4" },
         }),
       );
 
-      expect(mockCreate.mock.calls[0][0].model).toBe("gpt-5.2");
+      expect(mockCreate.mock.calls[0][0].model).toBe("gpt-5.4");
     });
   });
 

--- a/tests/unit/app/api/chat/route.test.ts
+++ b/tests/unit/app/api/chat/route.test.ts
@@ -68,7 +68,7 @@ describe("POST /api/chat", () => {
       });
 
       const settings = {
-        model: "gpt-5.2",
+        model: "gpt-5.4",
         reasoningEffort: "high",
         responseLanguage: "zh",
         webSearchEnabled: true,
@@ -78,7 +78,7 @@ describe("POST /api/chat", () => {
 
       expect(mockCreateResponse).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: "gpt-5.2",
+          model: "gpt-5.4",
           input: "Hello",
           reasoningEffort: "high",
           webSearchEnabled: true,

--- a/tests/unit/components/settings/SettingsForm.test.tsx
+++ b/tests/unit/components/settings/SettingsForm.test.tsx
@@ -43,8 +43,8 @@ describe("SettingsForm", () => {
     render(<SettingsForm />);
     // "Model" appears as section header and label
     expect(screen.getAllByText("Model").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText("GPT-5-mini")).toBeTruthy();
-    expect(screen.getByText("GPT-5.2")).toBeTruthy();
+    expect(screen.getByText("GPT-5.4-mini")).toBeTruthy();
+    expect(screen.getByText("GPT-5.4")).toBeTruthy();
   });
 
   it("renders Reasoning section", () => {
@@ -83,7 +83,7 @@ describe("SettingsForm", () => {
 
   it("calls updateModel when model button is clicked", () => {
     render(<SettingsForm />);
-    fireEvent.click(screen.getByText("GPT-5.2"));
+    fireEvent.click(screen.getByText("GPT-5.4"));
     expect(mockState.updateModel).toHaveBeenCalled();
   });
 });

--- a/tests/unit/components/settings/SettingsForm.test.tsx
+++ b/tests/unit/components/settings/SettingsForm.test.tsx
@@ -10,7 +10,7 @@ vi.mock("next/navigation", () => ({
 
 const mockState = createMockStoreState({
   settings: {
-    model: "gpt-5-mini",
+    model: "gpt-5.4-mini",
     reasoningEffort: "none",
     responseLanguage: "en",
     translateLanguage: "Chinese",

--- a/tests/unit/lib/api/blockAction.test.ts
+++ b/tests/unit/lib/api/blockAction.test.ts
@@ -84,7 +84,7 @@ describe("fetchBlockAction", () => {
     mockApiFetch.mockResolvedValue({ text: "ok" });
 
     const settings = {
-      model: "gpt-5.2" as const,
+      model: "gpt-5.4" as const,
       reasoningEffort: "high" as const,
       responseLanguage: "en" as const,
       translateLanguage: "English" as const,

--- a/tests/unit/lib/api/openAiClient.test.ts
+++ b/tests/unit/lib/api/openAiClient.test.ts
@@ -65,7 +65,7 @@ describe("openAiClient", () => {
       MockOpenAI.prototype.responses = { create: mockCreate };
 
       const result = await createResponse({
-        model: "gpt-5-mini",
+        model: "gpt-5.4-mini",
         input: "Hello",
         instructions: "Be helpful",
       });
@@ -74,7 +74,7 @@ describe("openAiClient", () => {
       expect(result.responseId).toBe("resp-123");
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: "gpt-5-mini",
+          model: "gpt-5.4-mini",
           input: "Hello",
           instructions: "Be helpful",
           store: true,
@@ -91,7 +91,7 @@ describe("openAiClient", () => {
       MockOpenAI.prototype.responses = { create: mockCreate };
 
       await createResponse({
-        model: "gpt-5-mini",
+        model: "gpt-5.4-mini",
         input: "Continue",
         previousResponseId: "resp-1",
       });
@@ -112,7 +112,7 @@ describe("openAiClient", () => {
       MockOpenAI.prototype.responses = { create: mockCreate };
 
       await createResponse({
-        model: "gpt-5-mini",
+        model: "gpt-5.4-mini",
         input: "Think hard",
         reasoningEffort: "high",
       });
@@ -133,7 +133,7 @@ describe("openAiClient", () => {
       MockOpenAI.prototype.responses = { create: mockCreate };
 
       await createResponse({
-        model: "gpt-5-mini",
+        model: "gpt-5.4-mini",
         input: "Quick",
         reasoningEffort: "none",
       });
@@ -151,7 +151,7 @@ describe("openAiClient", () => {
       MockOpenAI.prototype.responses = { create: mockCreate };
 
       await createResponse({
-        model: "gpt-5-mini",
+        model: "gpt-5.4-mini",
         input: "Search this",
         webSearchEnabled: true,
       });
@@ -172,7 +172,7 @@ describe("openAiClient", () => {
       MockOpenAI.prototype.responses = { create: mockCreate };
 
       const result = await createResponse({
-        model: "gpt-5-mini",
+        model: "gpt-5.4-mini",
         input: "Hello",
       });
 
@@ -187,7 +187,7 @@ describe("openAiClient", () => {
       MockOpenAI.prototype.responses = { create: mockCreate };
 
       await expect(
-        createResponse({ model: "gpt-5-mini", input: "Hello" }),
+        createResponse({ model: "gpt-5.4-mini", input: "Hello" }),
       ).rejects.toThrow("API rate limited");
     });
   });
@@ -219,7 +219,7 @@ describe("openAiClient", () => {
       };
 
       await createResponseStream(
-        { model: "gpt-5-mini", input: "Hello" },
+        { model: "gpt-5.4-mini", input: "Hello" },
         handler,
       );
 
@@ -245,7 +245,7 @@ describe("openAiClient", () => {
       };
 
       await createResponseStream(
-        { model: "gpt-5-mini", input: "Hello" },
+        { model: "gpt-5.4-mini", input: "Hello" },
         handler,
       );
 
@@ -279,7 +279,7 @@ describe("openAiClient", () => {
       };
 
       await createResponseStream(
-        { model: "gpt-5-mini", input: "Hello" },
+        { model: "gpt-5.4-mini", input: "Hello" },
         handler,
       );
 
@@ -305,7 +305,7 @@ describe("openAiClient", () => {
       };
 
       await createResponseStream(
-        { model: "gpt-5-mini", input: "Hello" },
+        { model: "gpt-5.4-mini", input: "Hello" },
         handler,
       );
 

--- a/tests/unit/lib/config/openai.test.ts
+++ b/tests/unit/lib/config/openai.test.ts
@@ -21,13 +21,13 @@ describe("getOpenAIModelConfig", () => {
   it("returns default model when env var not set", () => {
     delete process.env.OPENAI_MODEL;
     const config = getOpenAIModelConfig();
-    expect(config.model).toBe("gpt-5-mini");
+    expect(config.model).toBe("gpt-5.4-mini");
   });
 
   it("returns env var model when set", () => {
-    process.env.OPENAI_MODEL = "gpt-5.2";
+    process.env.OPENAI_MODEL = "gpt-5.4";
     const config = getOpenAIModelConfig();
-    expect(config.model).toBe("gpt-5.2");
+    expect(config.model).toBe("gpt-5.4");
   });
 });
 
@@ -93,8 +93,8 @@ describe("getBlockActionPrompt", () => {
 
 describe("calculateCost", () => {
   it("calculates cost for known model", () => {
-    // gpt-5-mini: input=0.25, output=2.00 per 1M tokens
-    const cost = calculateCost("gpt-5-mini", 1_000_000, 1_000_000);
+    // gpt-5.4-mini: input=0.25, output=2.00 per 1M tokens
+    const cost = calculateCost("gpt-5.4-mini", 1_000_000, 1_000_000);
     expect(cost).toBeCloseTo(0.25 + 2.0);
   });
 
@@ -103,12 +103,12 @@ describe("calculateCost", () => {
   });
 
   it("handles zero tokens", () => {
-    expect(calculateCost("gpt-5-mini", 0, 0)).toBe(0);
+    expect(calculateCost("gpt-5.4-mini", 0, 0)).toBe(0);
   });
 
   it("calculates fractional costs correctly", () => {
-    // 100 tokens of gpt-5.2: input=1.75/1M, output=14.00/1M
-    const cost = calculateCost("gpt-5.2", 100, 100);
+    // 100 tokens of gpt-5.4: input=1.75/1M, output=14.00/1M
+    const cost = calculateCost("gpt-5.4", 100, 100);
     const expected = (100 / 1_000_000) * 1.75 + (100 / 1_000_000) * 14.0;
     expect(cost).toBeCloseTo(expected);
   });

--- a/tests/unit/lib/state/settings.test.ts
+++ b/tests/unit/lib/state/settings.test.ts
@@ -18,7 +18,7 @@ describe("Settings State Functions", () => {
   describe("createInitialSettings", () => {
     it("should create settings with default values", () => {
       const settings = createInitialSettings();
-      expect(settings.model).toBe("gpt-5-mini");
+      expect(settings.model).toBe("gpt-5.4-mini");
       expect(settings.reasoningEffort).toBe("none");
       expect(settings.webSearchEnabled).toBe(false);
     });
@@ -62,14 +62,14 @@ describe("Settings State Functions", () => {
     it("should preserve other settings", () => {
       const settings: Settings = {
         systemPromptFile: "developer",
-        model: "gpt-5.2",
+        model: "gpt-5.4",
         reasoningEffort: "high",
         webSearchEnabled: true,
         responseLanguage: "zh",
         translateLanguage: "Spanish",
       };
       const updated = updateSystemPromptFile(settings, "chatgpt");
-      expect(updated.model).toBe("gpt-5.2");
+      expect(updated.model).toBe("gpt-5.4");
       expect(updated.reasoningEffort).toBe("high");
       expect(updated.webSearchEnabled).toBe(true);
       expect(updated.responseLanguage).toBe("zh");
@@ -78,35 +78,35 @@ describe("Settings State Functions", () => {
   });
 
   describe("updateModel", () => {
-    it("should update model to gpt-5.2", () => {
+    it("should update model to gpt-5.4", () => {
       const settings = createInitialSettings();
-      const updated = updateModel(settings, "gpt-5.2");
-      expect(updated.model).toBe("gpt-5.2");
+      const updated = updateModel(settings, "gpt-5.4");
+      expect(updated.model).toBe("gpt-5.4");
     });
 
-    it("should update model to gpt-5-mini", () => {
-      const settings: Settings = { ...DEFAULT_SETTINGS, model: "gpt-5.2" };
-      const updated = updateModel(settings, "gpt-5-mini");
-      expect(updated.model).toBe("gpt-5-mini");
+    it("should update model to gpt-5.4-mini", () => {
+      const settings: Settings = { ...DEFAULT_SETTINGS, model: "gpt-5.4" };
+      const updated = updateModel(settings, "gpt-5.4-mini");
+      expect(updated.model).toBe("gpt-5.4-mini");
     });
 
     it("should maintain immutability", () => {
       const settings = createInitialSettings();
-      const updated = updateModel(settings, "gpt-5.2");
+      const updated = updateModel(settings, "gpt-5.4");
       expect(updated).not.toBe(settings);
-      expect(settings.model).toBe("gpt-5-mini");
+      expect(settings.model).toBe("gpt-5.4-mini");
     });
 
     it("should preserve other settings", () => {
       const settings: Settings = {
         systemPromptFile: "chatgpt",
-        model: "gpt-5-mini",
+        model: "gpt-5.4-mini",
         reasoningEffort: "high",
         webSearchEnabled: true,
         responseLanguage: "en",
         translateLanguage: "English",
       };
-      const updated = updateModel(settings, "gpt-5.2");
+      const updated = updateModel(settings, "gpt-5.4");
       expect(updated.systemPromptFile).toBe("chatgpt");
       expect(updated.reasoningEffort).toBe("high");
       expect(updated.webSearchEnabled).toBe(true);
@@ -153,7 +153,7 @@ describe("Settings State Functions", () => {
     it("should preserve other settings", () => {
       const settings: Settings = {
         systemPromptFile: "chatgpt",
-        model: "gpt-5.2",
+        model: "gpt-5.4",
         reasoningEffort: "none",
         webSearchEnabled: true,
         responseLanguage: "zh",
@@ -161,7 +161,7 @@ describe("Settings State Functions", () => {
       };
       const updated = updateReasoningEffort(settings, "medium");
       expect(updated.systemPromptFile).toBe("chatgpt");
-      expect(updated.model).toBe("gpt-5.2");
+      expect(updated.model).toBe("gpt-5.4");
       expect(updated.webSearchEnabled).toBe(true);
       expect(updated.responseLanguage).toBe("zh");
       expect(updated.translateLanguage).toBe("Spanish");
@@ -194,7 +194,7 @@ describe("Settings State Functions", () => {
     it("should preserve other settings", () => {
       const settings: Settings = {
         systemPromptFile: "chatgpt",
-        model: "gpt-5.2",
+        model: "gpt-5.4",
         reasoningEffort: "high",
         webSearchEnabled: false,
         responseLanguage: "en",
@@ -202,7 +202,7 @@ describe("Settings State Functions", () => {
       };
       const updated = updateWebSearchEnabled(settings, true);
       expect(updated.systemPromptFile).toBe("chatgpt");
-      expect(updated.model).toBe("gpt-5.2");
+      expect(updated.model).toBe("gpt-5.4");
       expect(updated.reasoningEffort).toBe("high");
       expect(updated.responseLanguage).toBe("en");
       expect(updated.translateLanguage).toBe("French");
@@ -322,11 +322,11 @@ describe("Settings State Functions", () => {
     it("should preserve other settings", () => {
       const settings: Settings = {
         ...DEFAULT_SETTINGS,
-        model: "gpt-5.2",
+        model: "gpt-5.4",
         webSearchEnabled: true,
       };
       const updated = updateExportDestination(settings, "obsidian");
-      expect(updated.model).toBe("gpt-5.2");
+      expect(updated.model).toBe("gpt-5.4");
       expect(updated.webSearchEnabled).toBe(true);
     });
   });
@@ -358,11 +358,11 @@ describe("Settings State Functions", () => {
       const settings: Settings = {
         ...DEFAULT_SETTINGS,
         exportDestination: "obsidian",
-        model: "gpt-5.2",
+        model: "gpt-5.4",
       };
       const updated = updateObsidianVaultName(settings, "Vault");
       expect(updated.exportDestination).toBe("obsidian");
-      expect(updated.model).toBe("gpt-5.2");
+      expect(updated.model).toBe("gpt-5.4");
     });
   });
 

--- a/tests/unit/lib/store/slices/settingsSlice.test.ts
+++ b/tests/unit/lib/store/slices/settingsSlice.test.ts
@@ -24,7 +24,7 @@ describe("settingsSlice", () => {
 
   it("should have default settings on initialization", () => {
     const { settings } = useStore.getState();
-    expect(settings.model).toBe("gpt-5-mini");
+    expect(settings.model).toBe("gpt-5.4-mini");
     expect(settings.reasoningEffort).toBe("none");
     expect(settings.webSearchEnabled).toBe(false);
     expect(settings.responseLanguage).toBe("en");
@@ -34,18 +34,18 @@ describe("settingsSlice", () => {
   });
 
   describe("updateModel", () => {
-    it("should update model to gpt-5.2", () => {
-      useStore.getState().updateModel("gpt-5.2");
-      expect(useStore.getState().settings.model).toBe("gpt-5.2");
+    it("should update model to gpt-5.4", () => {
+      useStore.getState().updateModel("gpt-5.4");
+      expect(useStore.getState().settings.model).toBe("gpt-5.4");
     });
 
     it("should preserve other settings when updating model", () => {
       useStore.getState().updateReasoningEffort("high");
       useStore.getState().updateWebSearchEnabled(true);
-      useStore.getState().updateModel("gpt-5.2");
+      useStore.getState().updateModel("gpt-5.4");
 
       const { settings } = useStore.getState();
-      expect(settings.model).toBe("gpt-5.2");
+      expect(settings.model).toBe("gpt-5.4");
       expect(settings.reasoningEffort).toBe("high");
       expect(settings.webSearchEnabled).toBe(true);
     });
@@ -127,7 +127,7 @@ describe("settingsSlice", () => {
 
   describe("resetSettings", () => {
     it("should reset all settings to defaults", () => {
-      useStore.getState().updateModel("gpt-5.2");
+      useStore.getState().updateModel("gpt-5.4");
       useStore.getState().updateReasoningEffort("high");
       useStore.getState().updateWebSearchEnabled(true);
       useStore.getState().updateResponseLanguage("zh");
@@ -138,7 +138,7 @@ describe("settingsSlice", () => {
       useStore.getState().resetSettings();
 
       const { settings } = useStore.getState();
-      expect(settings.model).toBe("gpt-5-mini");
+      expect(settings.model).toBe("gpt-5.4-mini");
       expect(settings.reasoningEffort).toBe("none");
       expect(settings.webSearchEnabled).toBe(false);
       expect(settings.responseLanguage).toBe("en");

--- a/tests/unit/lib/store/slices/uiSlice.test.ts
+++ b/tests/unit/lib/store/slices/uiSlice.test.ts
@@ -103,7 +103,7 @@ describe("uiSlice", () => {
       ]);
       useStore.getState().setAwaitingResponse(true);
       useStore.getState().setError("error");
-      useStore.getState().updateModel("gpt-5.2");
+      useStore.getState().updateModel("gpt-5.4");
 
       // Reset
       useStore.getState().reset();
@@ -120,7 +120,7 @@ describe("uiSlice", () => {
       expect(state.streamingMessage).toBeNull();
 
       // Settings should be preserved
-      expect(state.settings.model).toBe("gpt-5.2");
+      expect(state.settings.model).toBe("gpt-5.4");
     });
   });
 });

--- a/types/settings.ts
+++ b/types/settings.ts
@@ -1,4 +1,4 @@
-export type ModelType = "gpt-5.2" | "gpt-5-mini";
+export type ModelType = "gpt-5.4" | "gpt-5.4-mini";
 export type ReasoningEffort = "none" | "low" | "medium" | "high";
 export type ResponseLanguage = "en" | "es" | "fr" | "zh" | "ja";
 export type TranslateLanguage =
@@ -76,7 +76,7 @@ export interface Settings {
 
 export const DEFAULT_SETTINGS: Settings = {
   systemPromptFile: "developer",
-  model: "gpt-5-mini",
+  model: "gpt-5.4-mini",
   reasoningEffort: "none",
   webSearchEnabled: false,
   responseLanguage: "en",


### PR DESCRIPTION
## Summary

- Renames `gpt-5.2` → `gpt-5.4` and `gpt-5-mini` → `gpt-5.4-mini` across the entire codebase
- Updates the `ModelType` union type, default model fallback, pricing table keys, and Settings panel labels
- Updates all unit tests and documentation to match the new model names

## Files changed

| Layer | Files |
|-------|-------|
| Types | `types/settings.ts` |
| Backend config | `lib/config/openai.ts` |
| Frontend UI | `components/settings/SettingsForm.tsx` |
| Docs | `README.md`, `tests/integration/README.md` |
| Tests | 9 unit test files |

## Test plan

- [ ] Run `npm run test` — all unit tests should pass with updated model name strings
- [ ] Open Settings panel in the app and confirm the two model options show "GPT-5.4-mini" and "GPT-5.4"
- [ ] Verify a chat request uses the correct model name in the API call