### PR TITLE
feat: sticky API key banner & simpler Obsidian vault settings

### DIFF
--- a/app/landing-content.tsx
+++ b/app/landing-content.tsx
@@ -35,7 +35,6 @@ export function LandingContent() {
       onPromptChange={setPrompt}
       onSubmit={handleSubmit}
       disabled={isDisabled}
-      needsApiKey={needsApiKey}
     />
   );
 }

--- a/components/empty-state/EmptyState.tsx
+++ b/components/empty-state/EmptyState.tsx
@@ -8,7 +8,6 @@ interface EmptyStateProps {
   onPromptChange: (value: string) => void;
   onSubmit: (e: FormEvent) => void;
   disabled?: boolean;
-  needsApiKey?: boolean;
 }
 
 export function EmptyState({
@@ -16,7 +15,6 @@ export function EmptyState({
   onPromptChange,
   onSubmit,
   disabled = false,
-  needsApiKey = false,
 }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center min-h-[calc(100vh-4rem)] px-6">
@@ -31,11 +29,6 @@ export function EmptyState({
       </div>
 
       <div className="w-full max-w-2xl">
-        {needsApiKey && (
-          <div className="mb-4 rounded-lg border border-border bg-muted/30 p-3 text-sm text-muted-foreground text-center">
-            Add your OpenAI API key in <span className="font-medium">Settings</span> to start chatting.
-          </div>
-        )}
         <Composer
           selectedBlockId={null}
           prompt={prompt}

--- a/components/layout/ApiKeyBanner.tsx
+++ b/components/layout/ApiKeyBanner.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useStore } from "@/lib/store/useStore";
+
+export function ApiKeyBanner() {
+  const apiKey = useStore((state) => state.settings.apiKey);
+
+  const [hasMounted, setHasMounted] = useState(false);
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
+  if (!hasMounted || apiKey) return null;
+
+  return (
+    <div className="sticky top-0 z-40 border-b border-border bg-muted/80 px-4 py-2 text-center text-sm text-muted-foreground backdrop-blur">
+      Add your OpenAI API key in <span className="font-medium">Settings</span>{" "}
+      to start chatting.
+    </div>
+  );
+}

--- a/components/layout/AppLayout.tsx
+++ b/components/layout/AppLayout.tsx
@@ -3,6 +3,7 @@
 import { ReactNode } from "react";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/sidebar/AppSidebar";
+import { ApiKeyBanner } from "./ApiKeyBanner";
 
 interface AppLayoutProps {
   children: ReactNode;
@@ -12,7 +13,10 @@ export function AppLayout({ children }: AppLayoutProps) {
   return (
     <SidebarProvider defaultOpen={true}>
       <AppSidebar />
-      <SidebarInset>{children}</SidebarInset>
+      <SidebarInset>
+        <ApiKeyBanner />
+        {children}
+      </SidebarInset>
     </SidebarProvider>
   );
 }

--- a/components/settings/SettingsForm.tsx
+++ b/components/settings/SettingsForm.tsx
@@ -23,7 +23,6 @@ import type {
   ReasoningEffort,
   ResponseLanguage,
   TranslateLanguage,
-  ExportDestination,
 } from "@/types/settings";
 
 const MODEL_OPTIONS: {
@@ -94,6 +93,11 @@ export function SettingsForm() {
     (opt) => TRANSLATE_TO_RESPONSE_MAP[opt.value] !== settings.responseLanguage,
   );
 
+  const handleVaultNameChange = (value: string) => {
+    updateObsidianVaultName(value);
+    updateExportDestination(value.trim() ? "obsidian" : "local");
+  };
+
   return (
     <div className="flex flex-col gap-5 py-4">
       <div className="space-y-2">
@@ -110,6 +114,25 @@ export function SettingsForm() {
         />
         <p className="text-xs text-muted-foreground">
           Stored locally in your browser. Never sent to any server besides OpenAI.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="obsidian-vault" className="text-sm font-medium">
+          Obsidian Vault Name
+        </Label>
+        <Input
+          id="obsidian-vault"
+          type="text"
+          autoComplete="off"
+          value={settings.obsidianVaultName ?? ""}
+          onChange={(e) => handleVaultNameChange(e.target.value)}
+          placeholder="MyVault"
+        />
+        <p className="text-xs text-muted-foreground">
+          Fill this in to send exported threads and cards straight to your
+          Obsidian vault. Leave empty to download them as Markdown files
+          instead.
         </p>
       </div>
 
@@ -252,57 +275,6 @@ export function SettingsForm() {
           </RadioGroup>
       </div>
 
-      <div className="space-y-2">
-        <Label className="text-sm font-medium">Export Destination</Label>
-          <RadioGroup
-            value={settings.exportDestination}
-            onValueChange={(value) =>
-              updateExportDestination(value as ExportDestination)
-            }
-            className="grid gap-2"
-          >
-            <label
-              htmlFor="export-local"
-              className={`flex items-center space-x-3 rounded-lg border p-3 cursor-pointer transition-colors ${
-                settings.exportDestination === "local"
-                  ? "border-foreground/20 bg-accent"
-                  : "border-border hover:bg-muted/50"
-              }`}
-            >
-              <RadioGroupItem value="local" id="export-local" />
-              <div className="flex flex-col">
-                <span className="text-sm font-medium">Local</span>
-                <span className="text-xs text-muted-foreground">
-                  Browser download
-                </span>
-              </div>
-            </label>
-            <label
-              htmlFor="export-obsidian"
-              className={`flex items-center space-x-3 rounded-lg border p-3 cursor-pointer transition-colors ${
-                settings.exportDestination === "obsidian"
-                  ? "border-foreground/20 bg-accent"
-                  : "border-border hover:bg-muted/50"
-              }`}
-            >
-              <RadioGroupItem value="obsidian" id="export-obsidian" />
-              <div className="flex flex-col">
-                <span className="text-sm font-medium">Obsidian</span>
-                <span className="text-xs text-muted-foreground">
-                  Open in Obsidian via URI
-                </span>
-              </div>
-            </label>
-          </RadioGroup>
-          {settings.exportDestination === "obsidian" && (
-            <Input
-              value={settings.obsidianVaultName ?? ""}
-              onChange={(e) => updateObsidianVaultName(e.target.value)}
-              placeholder="MyVault"
-              className="mt-2"
-            />
-          )}
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
Two cosmetic polish changes.

## 1. Sticky API key banner

**Before:** The "Add your OpenAI API key in Settings to start chatting" banner only appeared inside the landing page's `EmptyState` component — so users who imported a thread URL or landed directly on `/t/[threadId]` got no reminder.

**After:** A new `ApiKeyBanner` component is rendered at the top of `SidebarInset` inside `AppLayout`. It:
- Sticks to the top of the main content column via `sticky top-0 z-40`
- Sits inside `SidebarInset`, so it doesn't cover the sidebar
- Hides automatically once `settings.apiKey` is filled
- Uses a mount-gate (same pattern as `landing-content.tsx`) to avoid SSR hydration mismatch

The old inline banner inside `EmptyState` is removed to avoid duplication. The composer `disabled` state still tracks `needsApiKey` locally.

## 2. Simplified Obsidian settings

**Before:** A radio group ("Export Destination") with Local / Obsidian options at the bottom of the Settings panel. When "Obsidian" was selected, an extra Input appeared for the vault name.

**After:** A single "Obsidian Vault Name" text input, placed directly below "OpenAI API Key" and matching its visual style (`Label` + `Input` + helper `<p>`).

- Fill the field → exports go to Obsidian
- Leave it empty → exports download as Markdown files

Export destination is derived automatically in the form handler (`handleVaultNameChange`): non-empty value sets `exportDestination = "obsidian"`, empty sets it to `"local"`. No changes to `lib/export/exportMarkdown.ts` or any other downstream logic — the existing `ExportDestination` machinery is still the source of truth, we just drive it from a single input.

Helper copy: _"Fill this in to send exported threads and cards straight to your Obsidian vault. Leave empty to download them as Markdown files instead."_

## Test plan

- [x] `npm run build` — green
- [x] `npx vitest run` — 819/819 passing
- [x] Manual smoke test: landing page shows banner when no key, settings panel shows new layout, no Export Destination radio
- [ ] Verify banner also appears on `/t/[threadId]` when key is absent
- [ ] Verify banner disappears after entering a key
- [ ] Verify export still works for both paths (vault-empty → download, vault-set → opens Obsidian)