### PR TITLE
feat: chain follow-up ask questions via previous_response_id

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -248,7 +248,19 @@ Streaming is handled by the OpenAI SDK's async iterator; the client dispatches `
 
 ### Ask-mode Q&A chain
 
-When a block is selected, the composer is in `ask` mode. Each `'ask'` call stores the returned `responseId` in `useComposer`'s `askResponseIdRef`. The next ask on the same block passes that ID as `previousResponseId`, chaining the Q&A server-side via OpenAI's `previous_response_id` so follow-up questions include prior answers as context. The chain resets whenever `selectedBlockId` changes (entering, switching, or leaving block mode). Other block actions (`translate`, `eli5`, `expand`, `example`, `rewrite`) remain one-shot and do not participate in the chain.
+When a block is selected, the composer is in `ask` mode. Each `'ask'` call stores the returned `responseId` in `useComposer`'s `askChainRef`, tagged with the block ID it belongs to. The next ask on the same block passes that ID as `previousResponseId`, chaining the Q&A server-side via OpenAI's `previous_response_id` so follow-up questions include prior answers as context.
+
+**Prompt shape:**
+- *First ask:* the preamble anchors the model on the block — `"Answer the following question about the text below.\n\nQuestion: {prompt}\n\nText:\n\n{block}"`.
+- *Chained ask:* input is the raw `{prompt}` only. The block is already carried through the server-side chain; omitting the preamble lets the model resolve the question against the prior answer when that's what the user meant.
+
+**The chain is invalidated when any of the following happens** — the server-side stored context would otherwise go stale relative to what the user sees:
+1. The selected block changes (entering, switching, or leaving block mode).
+2. The selected block's `text`, `selections`, or `isRewritten` flag changes (edit, strikethrough, rewrite, undo) while it remains selected.
+3. A response arrives after the user switched blocks mid-request — the result is dropped (neither the prompt draft nor the chain is written) to avoid leaking state into the new session.
+4. Page reload — `askChainRef` is an in-memory ref; it does not persist.
+
+Other block actions (`translate`, `eli5`, `expand`, `example`, `rewrite`) remain one-shot and do not participate in the chain.
 
 ## Export Feature
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -242,9 +242,13 @@ The app has no backend route handlers for chat. Instead, the browser calls OpenA
 |--------|---------|
 | `lib/api/openAiClient.ts` | Thin wrapper around `openai` SDK (`dangerouslyAllowBrowser: true`), exposes `createResponse` and `createResponseStream` |
 | `lib/api/chat.ts` | `fetchChatCompletionStream(prompt, callbacks, threadId, previousResponseId, settings)` — streams assistant replies via callbacks |
-| `lib/api/blockAction.ts` | `fetchBlockAction(action, blockText, prompt, translateLanguage, settings)` — one-shot transformations (ELI5, translate, expand, etc.) |
+| `lib/api/blockAction.ts` | `fetchBlockAction(action, blockText, prompt, translateLanguage, settings, previousResponseId)` — one-shot transformations (ELI5, translate, expand, etc.); returns `{ text, responseId }` |
 
 Streaming is handled by the OpenAI SDK's async iterator; the client dispatches `onToken`, `onResponseId`, `onComplete`, and `onError` callbacks to the store.
+
+### Ask-mode Q&A chain
+
+When a block is selected, the composer is in `ask` mode. Each `'ask'` call stores the returned `responseId` in `useComposer`'s `askResponseIdRef`. The next ask on the same block passes that ID as `previousResponseId`, chaining the Q&A server-side via OpenAI's `previous_response_id` so follow-up questions include prior answers as context. The chain resets whenever `selectedBlockId` changes (entering, switching, or leaving block mode). Other block actions (`translate`, `eli5`, `expand`, `example`, `rewrite`) remain one-shot and do not participate in the chain.
 
 ## Export Feature
 

--- a/hooks/useComposer.ts
+++ b/hooks/useComposer.ts
@@ -47,11 +47,16 @@ export function useComposer(): UseComposerReturn {
   // Track previous selectedBlockId to detect block switches
   const prevSelectedBlockIdRef = useRef(selectedBlockId);
 
-  // Chain of prior 'ask' responses for the current block session.
-  // Lets follow-up questions include the last answer as context via
-  // OpenAI's previous_response_id. Reset whenever the selected block changes
-  // (entering, switching, or leaving block mode) — chain is per-session.
-  const askResponseIdRef = useRef<string | null>(null);
+  // Chain of prior 'ask' responses for the current block selection.
+  // Lets follow-up questions include the last answer as context via OpenAI's
+  // previous_response_id. Tagged with blockId so in-flight responses for a
+  // prior selection can be detected and dropped. Invalidated by any change to
+  // the selected block's grounding (text/selections/rewrite state), because
+  // the stored server-side context would no longer match what the user sees.
+  const askChainRef = useRef<{
+    blockId: string;
+    responseId: string;
+  } | null>(null);
 
   // Clear prompt when switching FROM one block TO another block
   // (Not when entering block mode from chat mode, or when exiting)
@@ -64,7 +69,7 @@ export function useComposer(): UseComposerReturn {
     }
 
     if (prev !== curr) {
-      askResponseIdRef.current = null;
+      askChainRef.current = null;
     }
 
     prevSelectedBlockIdRef.current = curr;
@@ -83,6 +88,17 @@ export function useComposer(): UseComposerReturn {
 
   const selectedBlock = useStore(selectSelectedBlock);
   const contentForTransform = useStore(useShallow(selectContentForTransform));
+
+  // Invalidate the ask chain whenever the selected block's grounding changes
+  // (edit, strikethrough, rewrite, undo). The chain's server-side context was
+  // built on the prior text, so follow-ups would answer against stale content.
+  const selectedBlockText = selectedBlock?.text;
+  const selectedBlockIsRewritten = selectedBlock?.isRewritten;
+  const selectedBlockSelectionsKey =
+    selectedBlock?.selections?.join(' ') ?? '';
+  useEffect(() => {
+    askChainRef.current = null;
+  }, [selectedBlockText, selectedBlockIsRewritten, selectedBlockSelectionsKey]);
   const addUserMessage = useStore((state) => state.addUserMessage);
   const addAssistantMessage = useStore((state) => state.addAssistantMessage);
   const clearSelection = useStore((state) => state.clearSelection);
@@ -154,9 +170,17 @@ export function useComposer(): UseComposerReturn {
         // Join all content blocks for transformation
         const contentText = contentForTransform.map((b) => b.text).join('\n\n');
 
+        // Capture the block the request is associated with so we can guard
+        // against the user switching/deselecting before the response returns.
+        const blockIdAtRequestTime = useStore.getState().selectedBlockId;
+
         // Only 'ask' chains context; other actions are one-shot transforms.
+        // Chain is only valid if it belongs to the current block.
         const previousResponseId =
-          action === 'ask' ? askResponseIdRef.current ?? undefined : undefined;
+          action === 'ask' &&
+          askChainRef.current?.blockId === blockIdAtRequestTime
+            ? askChainRef.current.responseId
+            : undefined;
 
         const result = await fetchBlockAction(
           action,
@@ -167,12 +191,21 @@ export function useComposer(): UseComposerReturn {
           previousResponseId
         );
 
+        // Drop the result if the user switched blocks or deselected during the
+        // request — writing it would leak state into a different session.
+        const stillSameBlock =
+          useStore.getState().selectedBlockId === blockIdAtRequestTime;
+        if (!stillSameBlock) return;
+
         // CRITICAL: Result goes to composer (editable draft), NOT as message
         setPrompt(result.text);
 
         // Extend the ask chain so follow-up questions carry prior context.
-        if (action === 'ask') {
-          askResponseIdRef.current = result.responseId;
+        if (action === 'ask' && blockIdAtRequestTime) {
+          askChainRef.current = {
+            blockId: blockIdAtRequestTime,
+            responseId: result.responseId,
+          };
         }
 
         // Clear error on success

--- a/hooks/useComposer.ts
+++ b/hooks/useComposer.ts
@@ -47,6 +47,12 @@ export function useComposer(): UseComposerReturn {
   // Track previous selectedBlockId to detect block switches
   const prevSelectedBlockIdRef = useRef(selectedBlockId);
 
+  // Chain of prior 'ask' responses for the current block session.
+  // Lets follow-up questions include the last answer as context via
+  // OpenAI's previous_response_id. Reset whenever the selected block changes
+  // (entering, switching, or leaving block mode) — chain is per-session.
+  const askResponseIdRef = useRef<string | null>(null);
+
   // Clear prompt when switching FROM one block TO another block
   // (Not when entering block mode from chat mode, or when exiting)
   useEffect(() => {
@@ -55,6 +61,10 @@ export function useComposer(): UseComposerReturn {
 
     if (prev !== null && curr !== null && prev !== curr) {
       setPrompt('');
+    }
+
+    if (prev !== curr) {
+      askResponseIdRef.current = null;
     }
 
     prevSelectedBlockIdRef.current = curr;
@@ -144,16 +154,26 @@ export function useComposer(): UseComposerReturn {
         // Join all content blocks for transformation
         const contentText = contentForTransform.map((b) => b.text).join('\n\n');
 
+        // Only 'ask' chains context; other actions are one-shot transforms.
+        const previousResponseId =
+          action === 'ask' ? askResponseIdRef.current ?? undefined : undefined;
+
         const result = await fetchBlockAction(
           action,
           contentText,
           action === 'ask' ? prompt : undefined,
           action === 'translate' ? settings.translateLanguage : undefined,
-          settings
+          settings,
+          previousResponseId
         );
 
         // CRITICAL: Result goes to composer (editable draft), NOT as message
         setPrompt(result.text);
+
+        // Extend the ask chain so follow-up questions carry prior context.
+        if (action === 'ask') {
+          askResponseIdRef.current = result.responseId;
+        }
 
         // Clear error on success
         setError(null);

--- a/lib/api/blockAction.ts
+++ b/lib/api/blockAction.ts
@@ -40,6 +40,7 @@ export async function fetchBlockAction(
   prompt?: string,
   translateLanguage?: TranslateLanguage,
   settings?: Settings,
+  previousResponseId?: string,
 ): Promise<BlockActionResponse> {
   const trimmedBlockText = parseString(blockText);
   const trimmedPrompt = parseString(prompt);
@@ -66,7 +67,8 @@ export async function fetchBlockAction(
     instructions,
     reasoningEffort: settings.reasoningEffort,
     webSearchEnabled: settings.webSearchEnabled,
+    previousResponseId,
   });
 
-  return { text: result.text };
+  return { text: result.text, responseId: result.responseId };
 }

--- a/lib/api/blockAction.ts
+++ b/lib/api/blockAction.ts
@@ -60,10 +60,19 @@ export async function fetchBlockAction(
       ? getTranslatePrompt(translateLanguage)
       : getBlockActionPrompt(settings.responseLanguage);
 
+  // Chained 'ask' follow-ups: send the raw question only. The block text is
+  // already carried through OpenAI's previous_response_id chain, and omitting
+  // the "Answer the question about this text..." preamble lets the model
+  // resolve the question against the prior answer when appropriate.
+  const input =
+    action === "ask" && previousResponseId
+      ? (trimmedPrompt as string)
+      : buildInput(action, trimmedBlockText, trimmedPrompt);
+
   const result = await createResponse({
     apiKey: settings.apiKey,
     model: settings.model,
-    input: buildInput(action, trimmedBlockText, trimmedPrompt),
+    input,
     instructions,
     reasoningEffort: settings.reasoningEffort,
     webSearchEnabled: settings.webSearchEnabled,

--- a/tests/unit/hooks/useComposer.test.ts
+++ b/tests/unit/hooks/useComposer.test.ts
@@ -13,6 +13,9 @@ const { mockActions, mockStreamChat, mockFetchBlockAction } = vi.hoisted(
         webSearchEnabled: false,
       },
       selectedBlockId: null as string | null,
+      selectedBlockText: "Block text content",
+      selectedBlockIsRewritten: false,
+      selectedBlockSelections: [] as string[],
       rewriteBlock: vi.fn(),
       addUserMessage: vi.fn(),
       addAssistantMessage: vi.fn(),
@@ -43,7 +46,12 @@ vi.mock("@/lib/store/useStore", () => {
     useStore: useStoreFn,
     selectSelectedBlock: (state: typeof mockActions) => {
       if (!state.selectedBlockId) return null;
-      return { id: state.selectedBlockId, text: "Block text content" };
+      return {
+        id: state.selectedBlockId,
+        text: state.selectedBlockText,
+        selections: state.selectedBlockSelections,
+        isRewritten: state.selectedBlockIsRewritten,
+      };
     },
     selectContentForTransform: (state: typeof mockActions) => {
       if (!state.selectedBlockId) return [];
@@ -85,6 +93,9 @@ describe("useComposer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockActions.selectedBlockId = null;
+    mockActions.selectedBlockText = "Block text content";
+    mockActions.selectedBlockIsRewritten = false;
+    mockActions.selectedBlockSelections = [];
     mockActions.mode = "thread";
     mockActions.activeThreadId = "t1";
     mockActions.isAwaitingResponse = false;
@@ -607,6 +618,138 @@ describe("useComposer", () => {
         "ask",
         "Block text for transform",
         "question on new block",
+        undefined,
+        expect.any(Object),
+        undefined,
+      );
+    });
+
+    it("invalidates chain when the selected block's text changes (edit)", async () => {
+      mockActions.selectedBlockId = "b1";
+      mockFetchBlockAction
+        .mockResolvedValueOnce({ text: "first answer", responseId: "resp-1" })
+        .mockResolvedValueOnce({ text: "second answer", responseId: "resp-2" });
+
+      const { result, rerender } = renderHook(() => useComposer());
+
+      act(() => {
+        result.current.setPrompt("first question");
+      });
+      await act(async () => {
+        await result.current.handleBlockAction("ask");
+      });
+
+      // Simulate the user editing the block text while it remains selected.
+      mockActions.selectedBlockText = "Block text AFTER edit";
+      mockActions.selectedBlockIsRewritten = true;
+      rerender();
+
+      act(() => {
+        result.current.setPrompt("follow-up question");
+      });
+      await act(async () => {
+        await result.current.handleBlockAction("ask");
+      });
+
+      // Chain must NOT carry the stale previousResponseId into the post-edit ask.
+      expect(mockFetchBlockAction).toHaveBeenNthCalledWith(
+        2,
+        "ask",
+        "Block text for transform",
+        "follow-up question",
+        undefined,
+        expect.any(Object),
+        undefined,
+      );
+    });
+
+    it("invalidates chain when the selected block's selections change (strikethrough)", async () => {
+      mockActions.selectedBlockId = "b1";
+      mockFetchBlockAction
+        .mockResolvedValueOnce({ text: "first answer", responseId: "resp-1" })
+        .mockResolvedValueOnce({ text: "second answer", responseId: "resp-2" });
+
+      const { result, rerender } = renderHook(() => useComposer());
+
+      act(() => {
+        result.current.setPrompt("first question");
+      });
+      await act(async () => {
+        await result.current.handleBlockAction("ask");
+      });
+
+      // Simulate a strikethrough adding a selection.
+      mockActions.selectedBlockSelections = ["phrase"];
+      rerender();
+
+      act(() => {
+        result.current.setPrompt("follow-up question");
+      });
+      await act(async () => {
+        await result.current.handleBlockAction("ask");
+      });
+
+      expect(mockFetchBlockAction).toHaveBeenNthCalledWith(
+        2,
+        "ask",
+        "Block text for transform",
+        "follow-up question",
+        undefined,
+        expect.any(Object),
+        undefined,
+      );
+    });
+
+    it("drops response and preserves chain when block switches mid-request", async () => {
+      mockActions.selectedBlockId = "b1";
+      let resolveAsk: ((value: unknown) => void) | null = null;
+      mockFetchBlockAction.mockImplementationOnce(
+        () =>
+          new Promise((res) => {
+            resolveAsk = res;
+          }),
+      );
+
+      const { result, rerender } = renderHook(() => useComposer());
+
+      act(() => {
+        result.current.setPrompt("question on b1");
+      });
+
+      let askPromise: Promise<void>;
+      act(() => {
+        askPromise = result.current.handleBlockAction("ask");
+      });
+
+      // User switches block BEFORE the ask resolves.
+      mockActions.selectedBlockId = "b2";
+      rerender();
+
+      await act(async () => {
+        resolveAsk!({ text: "answer for b1", responseId: "resp-1" });
+        await askPromise!;
+      });
+
+      // Prompt on the new block should NOT be overwritten by b1's stale answer.
+      expect(result.current.prompt).not.toBe("answer for b1");
+
+      // Asking on b2 should start a fresh chain — no previousResponseId leaked.
+      mockFetchBlockAction.mockResolvedValueOnce({
+        text: "answer for b2",
+        responseId: "resp-2",
+      });
+      act(() => {
+        result.current.setPrompt("question on b2");
+      });
+      await act(async () => {
+        await result.current.handleBlockAction("ask");
+      });
+
+      expect(mockFetchBlockAction).toHaveBeenNthCalledWith(
+        2,
+        "ask",
+        "Block text for transform",
+        "question on b2",
         undefined,
         expect.any(Object),
         undefined,

--- a/tests/unit/hooks/useComposer.test.ts
+++ b/tests/unit/hooks/useComposer.test.ts
@@ -378,6 +378,7 @@ describe("useComposer", () => {
         mockActions.selectedBlockId = "b1";
         mockFetchBlockAction.mockResolvedValue({
           text: "AI response about block",
+          responseId: "resp-1",
         });
 
         const { result } = renderHook(() => useComposer());
@@ -396,6 +397,7 @@ describe("useComposer", () => {
           "What does this mean?",
           undefined,
           expect.any(Object),
+          undefined,
         );
         // Should NOT call streaming API
         expect(mockStreamChat).not.toHaveBeenCalled();
@@ -430,7 +432,10 @@ describe("useComposer", () => {
 
     it("calls fetchBlockAction and sets prompt to result", async () => {
       mockActions.selectedBlockId = "b1";
-      mockFetchBlockAction.mockResolvedValue({ text: "Simplified version" });
+      mockFetchBlockAction.mockResolvedValue({
+        text: "Simplified version",
+        responseId: "resp-1",
+      });
 
       const { result } = renderHook(() => useComposer());
 
@@ -444,6 +449,7 @@ describe("useComposer", () => {
         undefined,
         undefined,
         expect.any(Object),
+        undefined,
       );
       expect(result.current.prompt).toBe("Simplified version");
       expect(mockActions.setAwaitingResponse).toHaveBeenCalledWith(false);
@@ -451,7 +457,10 @@ describe("useComposer", () => {
 
     it("passes translate language for translate action", async () => {
       mockActions.selectedBlockId = "b1";
-      mockFetchBlockAction.mockResolvedValue({ text: "Translated" });
+      mockFetchBlockAction.mockResolvedValue({
+        text: "Translated",
+        responseId: "resp-1",
+      });
 
       const { result } = renderHook(() => useComposer());
 
@@ -465,12 +474,16 @@ describe("useComposer", () => {
         undefined,
         "zh-TW",
         expect.any(Object),
+        undefined,
       );
     });
 
     it("passes prompt for ask action", async () => {
       mockActions.selectedBlockId = "b1";
-      mockFetchBlockAction.mockResolvedValue({ text: "Answer" });
+      mockFetchBlockAction.mockResolvedValue({
+        text: "Answer",
+        responseId: "resp-1",
+      });
 
       const { result } = renderHook(() => useComposer());
 
@@ -488,6 +501,115 @@ describe("useComposer", () => {
         "My question",
         undefined,
         expect.any(Object),
+        undefined,
+      );
+    });
+
+    it("chains follow-up ask with previous responseId for same block", async () => {
+      mockActions.selectedBlockId = "b1";
+      mockFetchBlockAction
+        .mockResolvedValueOnce({ text: "warp means abc", responseId: "resp-1" })
+        .mockResolvedValueOnce({ text: "abc is ...", responseId: "resp-2" });
+
+      const { result } = renderHook(() => useComposer());
+
+      act(() => {
+        result.current.setPrompt("what does warp mean?");
+      });
+      await act(async () => {
+        await result.current.handleBlockAction("ask");
+      });
+
+      act(() => {
+        result.current.setPrompt("what is abc?");
+      });
+      await act(async () => {
+        await result.current.handleBlockAction("ask");
+      });
+
+      expect(mockFetchBlockAction).toHaveBeenNthCalledWith(
+        1,
+        "ask",
+        "Block text for transform",
+        "what does warp mean?",
+        undefined,
+        expect.any(Object),
+        undefined,
+      );
+      expect(mockFetchBlockAction).toHaveBeenNthCalledWith(
+        2,
+        "ask",
+        "Block text for transform",
+        "what is abc?",
+        undefined,
+        expect.any(Object),
+        "resp-1",
+      );
+    });
+
+    it("does not chain previousResponseId for non-ask actions", async () => {
+      mockActions.selectedBlockId = "b1";
+      mockFetchBlockAction
+        .mockResolvedValueOnce({ text: "answer", responseId: "resp-1" })
+        .mockResolvedValueOnce({ text: "simpler", responseId: "resp-2" });
+
+      const { result } = renderHook(() => useComposer());
+
+      act(() => {
+        result.current.setPrompt("a question");
+      });
+      await act(async () => {
+        await result.current.handleBlockAction("ask");
+      });
+
+      await act(async () => {
+        await result.current.handleBlockAction("eli5");
+      });
+
+      expect(mockFetchBlockAction).toHaveBeenNthCalledWith(
+        2,
+        "eli5",
+        "Block text for transform",
+        undefined,
+        undefined,
+        expect.any(Object),
+        undefined,
+      );
+    });
+
+    it("resets ask chain when a different block is selected", async () => {
+      mockActions.selectedBlockId = "b1";
+      mockFetchBlockAction
+        .mockResolvedValueOnce({ text: "first answer", responseId: "resp-1" })
+        .mockResolvedValueOnce({ text: "second answer", responseId: "resp-2" });
+
+      const { result, rerender } = renderHook(() => useComposer());
+
+      act(() => {
+        result.current.setPrompt("first question");
+      });
+      await act(async () => {
+        await result.current.handleBlockAction("ask");
+      });
+
+      mockActions.selectedBlockId = "b2";
+      rerender();
+
+      act(() => {
+        result.current.setPrompt("question on new block");
+      });
+      await act(async () => {
+        await result.current.handleBlockAction("ask");
+      });
+
+      expect(mockFetchBlockAction).toHaveBeenNthCalledWith(
+        2,
+        "ask",
+        "Block text for transform",
+        "question on new block",
+        undefined,
+        expect.any(Object),
+        undefined,
       );
     });
 

--- a/tests/unit/lib/api/blockAction.test.ts
+++ b/tests/unit/lib/api/blockAction.test.ts
@@ -128,7 +128,7 @@ describe("fetchBlockAction", () => {
     expect(params.instructions).toBe("translate prompt for Spanish");
   });
 
-  it("forwards previousResponseId to createResponse for ask chain", async () => {
+  it("forwards previousResponseId and drops preamble on chained ask", async () => {
     mockCreateResponse.mockResolvedValue({
       text: "Follow-up answer",
       responseId: "resp-2",
@@ -146,6 +146,30 @@ describe("fetchBlockAction", () => {
     const params = mockCreateResponse.mock.calls[0][0];
     expect(params.previousResponseId).toBe("resp-1");
     expect(result.responseId).toBe("resp-2");
+    // Chained ask sends just the raw question — no preamble, no block text.
+    expect(params.input).toBe("what is abc?");
+    expect(params.input).not.toContain("Answer the following question");
+    expect(params.input).not.toContain("block text");
+  });
+
+  it("keeps the preamble on the first ask (no previousResponseId)", async () => {
+    mockCreateResponse.mockResolvedValue({
+      text: "First answer",
+      responseId: "resp-1",
+    });
+
+    await fetchBlockAction(
+      "ask",
+      "block text",
+      "what does warp mean?",
+      undefined,
+      baseSettings,
+    );
+
+    const params = mockCreateResponse.mock.calls[0][0];
+    expect(params.input).toContain("Answer the following question");
+    expect(params.input).toContain("what does warp mean?");
+    expect(params.input).toContain("block text");
   });
 
   it("uses block action instructions for non-translate actions", async () => {

--- a/tests/unit/lib/api/blockAction.test.ts
+++ b/tests/unit/lib/api/blockAction.test.ts
@@ -128,6 +128,26 @@ describe("fetchBlockAction", () => {
     expect(params.instructions).toBe("translate prompt for Spanish");
   });
 
+  it("forwards previousResponseId to createResponse for ask chain", async () => {
+    mockCreateResponse.mockResolvedValue({
+      text: "Follow-up answer",
+      responseId: "resp-2",
+    });
+
+    const result = await fetchBlockAction(
+      "ask",
+      "block text",
+      "what is abc?",
+      undefined,
+      baseSettings,
+      "resp-1",
+    );
+
+    const params = mockCreateResponse.mock.calls[0][0];
+    expect(params.previousResponseId).toBe("resp-1");
+    expect(result.responseId).toBe("resp-2");
+  });
+
   it("uses block action instructions for non-translate actions", async () => {
     mockCreateResponse.mockResolvedValue({
       text: "Expanded",

--- a/types/api.ts
+++ b/types/api.ts
@@ -29,6 +29,7 @@ export interface BlockActionRequest {
 
 export interface BlockActionResponse {
   text: string;
+  responseId: string;
 }
 
 // Error Response


### PR DESCRIPTION
## Summary
- When a block is selected and the user asks a question, the returned response ID is stored per-block-session in `useComposer`.
- Follow-up asks on the same block pass it as `previousResponseId`, so OpenAI resolves them against the prior Q&A via `previous_response_id` (server-side state; no UI changes).
- Chain resets whenever `selectedBlockId` changes (entering, switching, or leaving block mode). Other block actions (`translate`, `eli5`, `expand`, `example`, `rewrite`) stay one-shot.

## User interaction flow
1. User selects a block → composer enters `ask` mode; `askResponseIdRef` is `null`.
2. User asks "what does warp mean?" → `fetchBlockAction('ask', ..., previousResponseId: undefined)` → response `resp-1` placed in composer as draft; ref = `resp-1`.
3. User clears draft, asks "what is abc?" → `fetchBlockAction('ask', ..., previousResponseId: 'resp-1')` → OpenAI resolves against the prior answer; ref updated to `resp-2`.
4. Selection changes → `useEffect` clears the ref; next ask starts fresh.

## Files changed
- **Production:** `types/api.ts`, `lib/api/blockAction.ts`, `hooks/useComposer.ts`
- **Docs:** `docs/architecture.md`
- **Tests:** `tests/unit/lib/api/blockAction.test.ts`, `tests/unit/hooks/useComposer.test.ts`

## Test plan
- [x] `npx vitest run tests/unit/lib/api/blockAction.test.ts tests/unit/hooks/useComposer.test.ts` — 39 passing (3 new ask-chain tests + 1 blockAction test)
- [x] `npx tsc --noEmit` — no new type errors in changed files
- [x] `npm run lint` — no new lint errors in changed files
- [ ] Manual: select a block, ask question A, follow up with a pronoun referring to A, verify the second answer has context.
- [ ] Manual: switch to a different block mid-conversation and verify the chain resets.