### PR TITLE
feat: auto-populate export card dialog filename

### DIFF
--- a/components/chat/CardControls.tsx
+++ b/components/chat/CardControls.tsx
@@ -9,6 +9,7 @@ import {
   blocksToCardMarkdown,
   generateCardFilename,
   exportMarkdown,
+  computeDefaultCardTitle,
 } from '@/lib/export';
 import { ExportCardDialog } from './ExportCardDialog';
 import { Block } from '@/types/block';
@@ -83,6 +84,21 @@ export function CardControls({ cardId, cardBlocks, onRemove }: CardControlsProps
         onOpenChange={setDialogOpen}
         onConfirm={handleExportCard}
         selectedBlockCount={blockCount}
+        defaultTitle={computeDefaultCardTitle(
+          activeThread?.title ?? '',
+          cardBlocks.length > 0
+            ? [
+                {
+                  id: cardId,
+                  messageId: cardBlocks[0].messageId,
+                  anchorBlockId: cardBlocks[0].id,
+                  blockIds: cardBlocks.map((b) => b.id),
+                  createdAt: 0,
+                },
+              ]
+            : [],
+          cardBlocks,
+        )}
       />
     </>
   );

--- a/components/chat/ExportButton.tsx
+++ b/components/chat/ExportButton.tsx
@@ -24,6 +24,7 @@ import {
   blocksToCardMarkdown,
   generateCardFilename,
   exportMarkdown,
+  computeDefaultCardTitle,
 } from '@/lib/export';
 import { ExportCardDialog } from './ExportCardDialog';
 
@@ -153,6 +154,11 @@ export function ExportButton() {
         onOpenChange={setDialogOpen}
         onConfirm={handleExportAllCards}
         selectedBlockCount={exportBlockCount}
+        defaultTitle={computeDefaultCardTitle(
+          activeThread?.title ?? '',
+          cards,
+          allBlocks,
+        )}
       />
     </>
   );

--- a/components/chat/ExportCardDialog.tsx
+++ b/components/chat/ExportCardDialog.tsx
@@ -30,13 +30,15 @@ export function ExportCardDialog({
 }: ExportCardDialogProps) {
   const [title, setTitle] = useState(defaultTitle);
 
-  // Reset title when dialog opens
+  // Reset title ONLY when dialog transitions from closed → open.
+  // `defaultTitle` is intentionally omitted from deps so that thread-title
+  // updates arriving while the dialog is open do not clobber user edits.
   useEffect(() => {
     if (open) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- Sync title with defaultTitle when dialog opens
       setTitle(defaultTitle);
     }
-  }, [open, defaultTitle]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
 
   const handleConfirm = () => {
     const trimmedTitle = title.trim();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -299,7 +299,18 @@ Key files:
 - `lib/export/download.ts` — Browser download utility `downloadMarkdown(content, filename)`
 - `lib/export/exportMarkdown.ts` — Unified export dispatcher (local download or Obsidian vault)
 - `lib/export/saveToVault.ts` — Server action to save markdown to an Obsidian vault
+- `lib/export/defaultCardTitle.ts` — Pure function `computeDefaultCardTitle(threadTitle, cards, blocks)` used by the Export Cards dialog to pre-populate the filename based on card anchor headings
 - `lib/export/index.ts` — Re-exports
+
+### Export Card Dialog Default Title
+
+When the Export Cards dialog opens, the filename input is pre-populated:
+
+- If a card's **anchor block** is a heading → `"{heading text} - {thread title}"` (picks the first heading-anchored card in document order)
+- Otherwise → `{thread title}`
+- If the thread title is empty, falls back to `"Untitled"`
+
+The per-card dialog (in `CardControls.tsx`) uses the same logic scoped to that single card. Thread title updates that arrive **while the dialog is already open** do not overwrite the user's in-progress edits — the default is only applied when the dialog transitions closed → open.
 
 ### Export Destination Setting
 

--- a/lib/export/defaultCardTitle.ts
+++ b/lib/export/defaultCardTitle.ts
@@ -1,0 +1,63 @@
+/**
+ * Compute the default filename suggestion for the Export Cards dialog.
+ *
+ * Rule:
+ * - If any card's anchor block is a heading → use the first such card's
+ *   heading text in document order: `"{heading} - {threadTitle}"`.
+ * - Otherwise → `threadTitle`.
+ *
+ * Fallbacks:
+ * - Empty/whitespace thread title → `"Untitled"`.
+ * - Heading text empty after stripping markdown `#` → use threadTitle alone.
+ * - Heading text longer than MAX_HEADING_CHARS → truncated.
+ */
+
+import type { Block } from "@/types/block";
+import type { Card } from "@/types/card";
+
+const MAX_HEADING_CHARS = 80;
+const FALLBACK_TITLE = "Untitled";
+
+export const stripHeadingMarkdown = (text: string): string => {
+  return text.replace(/^\s*#{1,6}\s*/, "").trim();
+};
+
+const truncate = (text: string, max: number): string => {
+  if (text.length <= max) return text;
+  return text.substring(0, max).trim();
+};
+
+export const computeDefaultCardTitle = (
+  threadTitle: string,
+  cards: Card[],
+  allBlocks: Block[],
+): string => {
+  const safeThreadTitle = threadTitle.trim() || FALLBACK_TITLE;
+
+  if (cards.length === 0) return safeThreadTitle;
+
+  const blockPosition = new Map<string, number>();
+  allBlocks.forEach((block, index) => blockPosition.set(block.id, index));
+
+  const headingAnchoredCards = cards
+    .map((card) => {
+      const anchor = allBlocks.find((b) => b.id === card.anchorBlockId);
+      return anchor && anchor.type === "heading"
+        ? { card, anchor, position: blockPosition.get(anchor.id) ?? Infinity }
+        : null;
+    })
+    .filter(
+      (entry): entry is { card: Card; anchor: Block; position: number } =>
+        entry !== null,
+    )
+    .sort((a, b) => a.position - b.position);
+
+  if (headingAnchoredCards.length === 0) return safeThreadTitle;
+
+  const rawHeading = stripHeadingMarkdown(headingAnchoredCards[0].anchor.text);
+  if (!rawHeading) return safeThreadTitle;
+
+  const heading = truncate(rawHeading, MAX_HEADING_CHARS);
+
+  return `${heading} - ${safeThreadTitle}`;
+};

--- a/lib/export/index.ts
+++ b/lib/export/index.ts
@@ -10,3 +10,5 @@ export {
 } from './markdownExport';
 
 export { exportMarkdown } from './exportMarkdown';
+
+export { computeDefaultCardTitle } from './defaultCardTitle';

--- a/tests/unit/components/chat/CardControls.test.tsx
+++ b/tests/unit/components/chat/CardControls.test.tsx
@@ -23,6 +23,7 @@ vi.mock('@/lib/export', () => ({
   blocksToCardMarkdown: (...args: unknown[]) => mockBlocksToCardMarkdown(...args),
   generateCardFilename: (...args: unknown[]) => mockGenerateCardFilename(...args),
   exportMarkdown: (...args: unknown[]) => mockExportMarkdown(...args),
+  computeDefaultCardTitle: () => 'Test Default',
 }));
 
 // Stub ExportCardDialog to capture props

--- a/tests/unit/components/chat/ExportButton.test.tsx
+++ b/tests/unit/components/chat/ExportButton.test.tsx
@@ -40,6 +40,7 @@ vi.mock('@/lib/export', () => ({
   blocksToCardMarkdown: (...args: unknown[]) => mockBlocksToCardMarkdown(...args),
   generateCardFilename: (...args: unknown[]) => mockGenerateCardFilename(...args),
   exportMarkdown: (...args: unknown[]) => mockExportMarkdown(...args),
+  computeDefaultCardTitle: () => 'Test Default',
 }));
 
 // Stub ExportCardDialog

--- a/tests/unit/lib/export/defaultCardTitle.test.ts
+++ b/tests/unit/lib/export/defaultCardTitle.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeDefaultCardTitle,
+  stripHeadingMarkdown,
+} from '@/lib/export/defaultCardTitle';
+import type { Block } from '@/types/block';
+import type { Card } from '@/types/card';
+
+const makeBlock = (overrides: Partial<Block>): Block => ({
+  id: 'b1',
+  messageId: 'm1',
+  type: 'paragraph',
+  text: 'some text',
+  edited: false,
+  selections: [],
+  prevText: null,
+  isRewritten: false,
+  ...overrides,
+});
+
+const makeCard = (overrides: Partial<Card>): Card => ({
+  id: 'c1',
+  messageId: 'm1',
+  anchorBlockId: 'b1',
+  blockIds: ['b1'],
+  createdAt: 0,
+  ...overrides,
+});
+
+describe('stripHeadingMarkdown', () => {
+  it('strips a single leading #', () => {
+    expect(stripHeadingMarkdown('# Title')).toBe('Title');
+  });
+
+  it('strips multiple leading #', () => {
+    expect(stripHeadingMarkdown('### Title')).toBe('Title');
+  });
+
+  it('trims whitespace', () => {
+    expect(stripHeadingMarkdown('##   Title  ')).toBe('Title');
+  });
+
+  it('returns empty when only hashes', () => {
+    expect(stripHeadingMarkdown('###')).toBe('');
+  });
+
+  it('leaves non-heading text alone', () => {
+    expect(stripHeadingMarkdown('Just text')).toBe('Just text');
+  });
+});
+
+describe('computeDefaultCardTitle', () => {
+  const threadTitle = 'Thread Title';
+
+  it('returns thread title when no cards exist', () => {
+    expect(computeDefaultCardTitle(threadTitle, [], [])).toBe('Thread Title');
+  });
+
+  it('returns thread title when no card anchors a heading', () => {
+    const blocks = [
+      makeBlock({ id: 'b1', type: 'paragraph', text: 'Para 1' }),
+      makeBlock({ id: 'b2', type: 'paragraph', text: 'Para 2' }),
+    ];
+    const cards = [makeCard({ id: 'c1', anchorBlockId: 'b1' })];
+    expect(computeDefaultCardTitle(threadTitle, cards, blocks)).toBe(
+      'Thread Title',
+    );
+  });
+
+  it('uses heading text when a card anchors a heading', () => {
+    const blocks = [
+      makeBlock({ id: 'b1', type: 'heading', text: '## Introduction' }),
+      makeBlock({ id: 'b2', type: 'paragraph', text: 'Body' }),
+    ];
+    const cards = [makeCard({ id: 'c1', anchorBlockId: 'b1' })];
+    expect(computeDefaultCardTitle(threadTitle, cards, blocks)).toBe(
+      'Introduction - Thread Title',
+    );
+  });
+
+  it('ignores a heading later in the card — only the anchor matters', () => {
+    const blocks = [
+      makeBlock({ id: 'b1', type: 'paragraph', text: 'Para' }),
+      makeBlock({ id: 'b2', type: 'heading', text: '# Later' }),
+    ];
+    const cards = [makeCard({ id: 'c1', anchorBlockId: 'b1' })];
+    expect(computeDefaultCardTitle(threadTitle, cards, blocks)).toBe(
+      'Thread Title',
+    );
+  });
+
+  it('picks the first heading-anchored card in document order', () => {
+    const blocks = [
+      makeBlock({ id: 'b1', type: 'paragraph', text: 'p1' }),
+      makeBlock({ id: 'b2', type: 'heading', text: '# First Heading' }),
+      makeBlock({ id: 'b3', type: 'paragraph', text: 'p2' }),
+      makeBlock({ id: 'b4', type: 'heading', text: '# Second Heading' }),
+    ];
+    const cards = [
+      makeCard({ id: 'c2', anchorBlockId: 'b4' }),
+      makeCard({ id: 'c1', anchorBlockId: 'b2' }),
+    ];
+    expect(computeDefaultCardTitle(threadTitle, cards, blocks)).toBe(
+      'First Heading - Thread Title',
+    );
+  });
+
+  it('falls back to thread title when heading text is empty after stripping', () => {
+    const blocks = [makeBlock({ id: 'b1', type: 'heading', text: '###' })];
+    const cards = [makeCard({ id: 'c1', anchorBlockId: 'b1' })];
+    expect(computeDefaultCardTitle(threadTitle, cards, blocks)).toBe(
+      'Thread Title',
+    );
+  });
+
+  it('uses "Untitled" when thread title is empty', () => {
+    const blocks = [
+      makeBlock({ id: 'b1', type: 'paragraph', text: 'Para' }),
+    ];
+    const cards = [makeCard({ id: 'c1', anchorBlockId: 'b1' })];
+    expect(computeDefaultCardTitle('', cards, blocks)).toBe('Untitled');
+  });
+
+  it('uses "Untitled" when thread title is whitespace only', () => {
+    expect(computeDefaultCardTitle('   ', [], [])).toBe('Untitled');
+  });
+
+  it('combines heading with Untitled when thread title is empty', () => {
+    const blocks = [
+      makeBlock({ id: 'b1', type: 'heading', text: '# Anchor' }),
+    ];
+    const cards = [makeCard({ id: 'c1', anchorBlockId: 'b1' })];
+    expect(computeDefaultCardTitle('', cards, blocks)).toBe(
+      'Anchor - Untitled',
+    );
+  });
+
+  it('truncates a very long heading', () => {
+    const longHeading = 'A'.repeat(200);
+    const blocks = [
+      makeBlock({ id: 'b1', type: 'heading', text: `# ${longHeading}` }),
+    ];
+    const cards = [makeCard({ id: 'c1', anchorBlockId: 'b1' })];
+    const result = computeDefaultCardTitle(threadTitle, cards, blocks);
+    expect(result.length).toBeLessThan(longHeading.length + threadTitle.length);
+    expect(result.endsWith(' - Thread Title')).toBe(true);
+  });
+
+  it('falls back to thread title when anchor block is missing from allBlocks', () => {
+    const blocks = [
+      makeBlock({ id: 'b2', type: 'paragraph', text: 'Para' }),
+    ];
+    const cards = [makeCard({ id: 'c1', anchorBlockId: 'missing' })];
+    expect(computeDefaultCardTitle(threadTitle, cards, blocks)).toBe(
+      'Thread Title',
+    );
+  });
+
+  it('skips non-heading-anchored cards and uses a later heading-anchored one', () => {
+    const blocks = [
+      makeBlock({ id: 'b1', type: 'paragraph', text: 'Para' }),
+      makeBlock({ id: 'b2', type: 'heading', text: '## Real Heading' }),
+    ];
+    const cards = [
+      makeCard({ id: 'c1', anchorBlockId: 'b1' }),
+      makeCard({ id: 'c2', anchorBlockId: 'b2' }),
+    ];
+    expect(computeDefaultCardTitle(threadTitle, cards, blocks)).toBe(
+      'Real Heading - Thread Title',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Pre-fills the Export Cards dialog filename based on card content. If a card is anchored on a heading, the default is `{heading} - {thread title}`; otherwise the thread title alone. Falls back to `Untitled` when the thread has no title.
- Same defaulting applied to per-card export triggered from `CardControls`.
- Guards against late thread-title updates (e.g. AI-generated title arriving after the dialog opens) overwriting a filename the user is actively editing — the default is applied only on the closed → open transition.

## User interaction flow
1. User creates one or more cards, clicks **Export Cards** → dialog opens with the filename pre-populated from `defaultCardTitle`.
2. If the card is anchored on a heading block, the field shows `{heading} - {thread title}`; otherwise just `{thread title}`.
3. User can edit freely; if the AI-generated thread title arrives while the dialog is open, the field is NOT overwritten.
4. Same flow when clicking the Export icon inside a single `CardControls`.

## Files changed
- **Production:** `lib/export/defaultCardTitle.ts` (new), `lib/export/index.ts`, `components/chat/ExportCardDialog.tsx`, `components/chat/ExportButton.tsx`, `components/chat/CardControls.tsx`
- **Docs:** `docs/architecture.md`
- **Tests:** `tests/unit/lib/export/defaultCardTitle.test.ts` (new, 172 lines), `tests/unit/components/chat/ExportButton.test.tsx`, `tests/unit/components/chat/CardControls.test.tsx`

## Test plan
- [x] `npx vitest run` — all 846 unit tests pass (includes new `defaultCardTitle` suite).
- [x] `npx playwright test e2e/mock/card-mode.spec.ts` — 63/63 e2e pass (chromium, firefox, webkit).
- [ ] Manual: create card anchored on a heading → open Export Cards → verify filename is `{heading} - {thread title}`.
- [ ] Manual: create card on a non-heading block → verify filename is `{thread title}`.
- [ ] Manual: open dialog before AI-generated title lands → verify user edits to filename are not overwritten when the title arrives.
- [ ] Manual: export a single card from `CardControls` → same defaulting applies.

Note: we're deferring an e2e case that specifically asserts the pre-populated value on dialog open — will bundle with an e2e refactor pass later.