### PR TITLE
perf: cut per-token re-render cost during streaming

### DIFF
--- a/components/chat/AssistantMessage.tsx
+++ b/components/chat/AssistantMessage.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { memo, useMemo } from 'react';
 import { Message } from '@/types/message';
 import { Block } from '@/types/block';
 import { Card } from '@/types/card';
@@ -22,7 +23,7 @@ interface AssistantMessageProps {
   onUndo?: (blockId: string) => void;
 }
 
-export function AssistantMessage({
+export const AssistantMessage = memo(function AssistantMessage({
   message,
   blocks,
   selectedBlockId = null,
@@ -34,8 +35,13 @@ export function AssistantMessage({
   onRewrite,
   onUndo,
 }: AssistantMessageProps) {
-  // Filter cards to only those belonging to this message
-  const messageCards = cards.filter((c) => c.messageId === message.id);
+  // Cards only change on explicit user action, not during streaming, so
+  // memoizing keeps the BlockStack's `cards` prop referentially stable
+  // across every streaming token.
+  const messageCards = useMemo(
+    () => cards.filter((c) => c.messageId === message.id),
+    [cards, message.id],
+  );
 
   return (
     <div className="assistant-message">
@@ -53,4 +59,4 @@ export function AssistantMessage({
       />
     </div>
   );
-}
+});

--- a/components/chat/MessageList.tsx
+++ b/components/chat/MessageList.tsx
@@ -18,6 +18,10 @@ interface StreamingMessageData {
   blocks: BlockData[];
 }
 
+// Stable empty array so AssistantMessage's `cards` prop keeps identity
+// across streaming re-renders (new [] per render would defeat memo).
+const EMPTY_CARDS: Card[] = [];
+
 /**
  * Client Component - Container for all messages in a thread
  * Needs 'use client' for scroll handling and state
@@ -88,6 +92,35 @@ export function MessageList({
     [blocks]
   );
 
+  // Streaming message + its synthesized blocks change identity on every
+  // token otherwise, forcing AssistantMessage + BlockStack to re-render
+  // even for unchanged blocks.
+  const streamingAssistantMessage = useMemo(() => {
+    if (!streamingMessage) return null;
+    return {
+      id: streamingMessage.messageId,
+      threadId: streamingMessage.threadId,
+      role: 'assistant' as const,
+      createdAt: streamingTimestamp ?? 0,
+      content: streamingMessage.blocks.map((_, i) => ({ blockId: `stream-${i}` })),
+      meta: {},
+    };
+  }, [streamingMessage, streamingTimestamp]);
+
+  const streamingBlocks = useMemo<Block[]>(() => {
+    if (!streamingMessage) return [];
+    return streamingMessage.blocks.map((blockData, i) => ({
+      id: `stream-${i}`,
+      messageId: streamingMessage.messageId,
+      type: blockData.type,
+      text: blockData.text,
+      edited: false,
+      selections: [],
+      prevText: null,
+      isRewritten: false,
+    }));
+  }, [streamingMessage]);
+
   return (
     <div
       ref={containerRef}
@@ -124,29 +157,13 @@ export function MessageList({
       })}
 
       {/* Streaming message (in-progress response) */}
-      {streamingMessage && streamingMessage.blocks.length > 0 && (
+      {streamingAssistantMessage && streamingBlocks.length > 0 && (
         <AssistantMessage
           key="streaming"
-          message={{
-            id: streamingMessage.messageId,
-            threadId: streamingMessage.threadId,
-            role: 'assistant',
-            createdAt: streamingTimestamp ?? 0,
-            content: streamingMessage.blocks.map((_, i) => ({ blockId: `stream-${i}` })),
-            meta: {},
-          }}
-          blocks={streamingMessage.blocks.map((blockData, i) => ({
-            id: `stream-${i}`,
-            messageId: streamingMessage.messageId,
-            type: blockData.type,
-            text: blockData.text,
-            edited: false,
-            selections: [],
-            prevText: null,
-            isRewritten: false,
-          }))}
+          message={streamingAssistantMessage}
+          blocks={streamingBlocks}
           selectedBlockId={null}
-          cards={[]}
+          cards={EMPTY_CARDS}
         />
       )}
 

--- a/components/content/BlockContent.tsx
+++ b/components/content/BlockContent.tsx
@@ -325,9 +325,18 @@ function renderCode(text: string, className?: string): React.ReactElement {
 
 /**
  * Main BlockContent component
- * Renders block text with appropriate formatting based on type
+ * Renders block text with appropriate formatting based on type.
+ *
+ * Memoized: during streaming every new token triggers a store update that
+ * ripples down the tree. Props here are all primitives, so the default
+ * shallow comparator is sufficient to skip re-parsing and re-rendering
+ * every finished block on every token.
  */
-export function BlockContent({ text, type, className = '' }: BlockContentProps) {
+export const BlockContent = React.memo(function BlockContent({
+  text,
+  type,
+  className = '',
+}: BlockContentProps) {
   if (!text) {
     return null;
   }
@@ -348,4 +357,4 @@ export function BlockContent({ text, type, className = '' }: BlockContentProps) 
     default:
       return <div className={className}>{text}</div>;
   }
-}
+});

--- a/lib/store/useStore.ts
+++ b/lib/store/useStore.ts
@@ -123,8 +123,8 @@ export const selectActiveThreadBlocks = (state: StoreState): Block[] => {
   const activeThread = selectActiveThread(state);
   if (!activeThread) return [];
 
-  const messageIds = activeThread.messages.map((m) => m.id);
-  return state.blocks.filter((b) => messageIds.includes(b.messageId));
+  const messageIds = new Set(activeThread.messages.map((m) => m.id));
+  return state.blocks.filter((b) => messageIds.has(b.messageId));
 };
 
 export const selectBlocksByThread =
@@ -132,6 +132,6 @@ export const selectBlocksByThread =
   (state: StoreState): Block[] => {
     const thread = state.threads.find((t) => t.id === threadId);
     if (!thread) return [];
-    const messageIds = thread.messages.map((m) => m.id);
-    return state.blocks.filter((b) => messageIds.includes(b.messageId));
+    const messageIds = new Set(thread.messages.map((m) => m.id));
+    return state.blocks.filter((b) => messageIds.has(b.messageId));
   };


### PR DESCRIPTION
## Summary

Four fixes from a performance review focused on the streaming hot path. Every new token currently forces every finished block to re-parse markdown + re-render KaTeX; this PR stops that.

- **\`React.memo\` on \`BlockContent\`** — biggest single win. Props are all primitives, so the default shallow comparator skips markdown/KaTeX re-parsing for every unchanged block on every token.
- **\`React.memo\` + \`useMemo\` on \`AssistantMessage\`** — the per-message \`cards.filter()\` and \`BlockStack\`'s \`cards\` prop are now referentially stable across streaming tokens. Cards only change on explicit user action.
- **Memoized streaming message + blocks in \`MessageList\`** — the streaming \`AssistantMessage\`'s \`message\` and \`blocks\` props were being rebuilt from fresh object literals on every render; they now come from \`useMemo\`. Also introduces a module-level \`EMPTY_CARDS\` so the empty-cards prop keeps identity.
- **Set-based selector membership** — \`selectActiveThreadBlocks\` and \`selectBlocksByThread\` switched from \`Array.includes\` to \`Set.has\` (O(b·m) → O(b+m)).

Findings came from an \`everything-claude-code:performance-optimizer\` agent sweep; remaining medium items (\`useShallow\` on \`useBlockSelection\`, localStorage write throttling, \`BlockStack\` duplicate \`Map\` build) are deferred.

## Test plan

- [x] \`npm run test\` — 863/863 passing
- [x] \`npm run lint\` — clean on touched files
- [x] \`npm run build\` — production build succeeds
- [x] Manual: send a long streaming message; confirm output still renders identically
- [x] Manual: React DevTools profiler during streaming — finished blocks should not re-render per token
- [x] Manual: verify card create / rewrite / undo still update correctly (those paths depend on memoization not being too aggressive)