### PR TITLE
fix: visual strikethrough in edit mode composer

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -112,6 +112,11 @@
     @apply text-gray-400 pointer-events-none;
   }
 
+  /* Strikethrough text */
+  del {
+    text-decoration: line-through;
+  }
+
   /* Text selection marks */
   mark.anno {
     @apply bg-yellow-200 rounded-sm;

--- a/components/composer/PromptInput.tsx
+++ b/components/composer/PromptInput.tsx
@@ -58,14 +58,45 @@ export function PromptInput({
       return;
     }
 
+    const selection = window.getSelection();
+    const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
+    const offset = range?.startOffset || 0;
+
+    // Render strikethrough markdown (~~text~~) as a <del> element for visual feedback
+    const strikethroughMatch = value.match(/^~~([\s\S]+)~~$/);
+    if (strikethroughMatch) {
+      const innerText = strikethroughMatch[1];
+      const childNodes = inputRef.current.childNodes;
+      const alreadyDel =
+        childNodes.length === 1 &&
+        childNodes[0].nodeName === 'DEL' &&
+        (childNodes[0] as HTMLElement).textContent === innerText;
+
+      if (!alreadyDel) {
+        const delEl = document.createElement('del');
+        delEl.textContent = innerText;
+        inputRef.current.innerHTML = '';
+        inputRef.current.appendChild(delEl);
+
+        if (selection && delEl.firstChild) {
+          try {
+            const newRange = document.createRange();
+            const maxOffset = (delEl.firstChild.textContent || '').length;
+            newRange.setStart(delEl.firstChild, Math.min(offset, maxOffset));
+            newRange.collapse(true);
+            selection.removeAllRanges();
+            selection.addRange(newRange);
+          } catch (e) {
+            // Ignore cursor restoration errors
+          }
+        }
+      }
+      return;
+    }
+
     // Only sync if value is actually different (external change)
     const currentText = inputRef.current.textContent || '';
     if (currentText.trim() !== value.trim()) {
-      // Save cursor position
-      const selection = window.getSelection();
-      const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
-      const offset = range?.startOffset || 0;
-
       // Update content
       inputRef.current.textContent = value;
 
@@ -89,8 +120,15 @@ export function PromptInput({
   const handleInput = () => {
     if (inputRef.current) {
       isUserInputRef.current = true;
-      const text = inputRef.current.textContent || '';
-      onChange(text.replace(/\u00a0/g, ' ').trim());
+      const childNodes = inputRef.current.childNodes;
+      // Preserve strikethrough markdown when entire content is a <del> element
+      if (childNodes.length === 1 && childNodes[0].nodeName === 'DEL') {
+        const delText = (childNodes[0] as HTMLElement).textContent || '';
+        onChange('~~' + delText.replace(/\u00a0/g, ' ').trim() + '~~');
+      } else {
+        const text = inputRef.current.textContent || '';
+        onChange(text.replace(/\u00a0/g, ' ').trim());
+      }
     }
   };
 
@@ -117,17 +155,18 @@ export function PromptInput({
 
       e.preventDefault();
 
-      // Wrap entire text in strikethrough
-      const newText = '~~' + fullText + '~~';
+      // Render visual strikethrough in the contenteditable using <del>
+      const delEl = document.createElement('del');
+      delEl.textContent = fullText;
+      inputRef.current.innerHTML = '';
+      inputRef.current.appendChild(delEl);
 
       isUserInputRef.current = true;
-      onChange(newText.replace(/\u00a0/g, ' ').trim());
+      onChange('~~' + fullText.replace(/\u00a0/g, ' ').trim() + '~~');
 
-      // Update DOM and position cursor at the end
-      inputRef.current.textContent = newText;
-
+      // Position cursor at end of del content
       try {
-        const textNode = inputRef.current.firstChild;
+        const textNode = delEl.firstChild;
         if (textNode && selection) {
           const newRange = document.createRange();
           const maxOffset = (textNode.textContent || '').length;

--- a/e2e/mock/direct-edit.spec.ts
+++ b/e2e/mock/direct-edit.spec.ts
@@ -254,9 +254,10 @@ test.describe('Direct Edit - Strikethrough', () => {
     // Select all and press backspace
     await chatPage.selectAllAndPress('Backspace');
 
-    // Verify text is wrapped in strikethrough
-    const newText = await chatPage.getPromptValue();
-    expect(newText).toBe(`~~${originalText}~~`);
+    // Verify the composer renders a <del> element (visual strikethrough)
+    const delEl = chatPage.promptInput.locator('del');
+    await expect(delEl).toBeVisible();
+    await expect(delEl).toHaveText(originalText);
   });
 
   test('should render strikethrough in block after Replace', async ({ page }) => {


### PR DESCRIPTION
## Summary

- After Ctrl+A + Backspace in edit mode, the composer now shows a `<del>` element with visual strikethrough instead of raw `~~text~~` characters
- The sync `useEffect` also detects `~~text~~` values (e.g. from `populateWithBlockText`) and renders them as `<del>` for consistent visual feedback
- `handleInput` preserves the `~~text~~` markdown representation when the contenteditable contains a single `<del>` child, so submission still works correctly
- Added explicit `del { text-decoration: line-through }` to `globals.css` so rendered blocks reliably show strikethrough rather than relying on browser defaults

## Test plan

- [ ] In edit mode, select a block and switch to Edit tab
- [ ] Press Ctrl+A to select all text in the composer
- [ ] Press Backspace — the text should appear with a line through it (not show `~~text~~`)
- [ ] Press Enter (Replace) — the block should update and render with strikethrough
- [ ] Undo the block rewrite and verify the original text is restored
- [ ] Verify no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)