### PR TITLE
chore(ci): add lint, typecheck, build gates; pause e2e

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,10 +1,10 @@
 name: E2E Tests
 
+# Disabled on push / PR while the Playwright suite is being rewritten for the
+# focus-mode refactor (see docs/focus-mode-todo.md §4). Trigger manually via
+# the Actions tab once the suite is functional again.
 on:
-  push:
-    branches: [main, develop]
-  pull_request:
-    branches: [main, develop]
+  workflow_dispatch:
 
 jobs:
   e2e-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,60 @@ on:
     branches: [main, master]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: TypeScript type check
+        run: npx tsc --noEmit
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Production build
+        run: npm run build
+
   test:
     runs-on: ubuntu-latest
 

--- a/app/landing-content.tsx
+++ b/app/landing-content.tsx
@@ -17,6 +17,7 @@ export function LandingContent() {
   // Avoid SSR/client hydration mismatch: treat apiKey as unknown until mounted.
   const [hasMounted, setHasMounted] = useState(false);
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- canonical SSR-safe mount flag
     setHasMounted(true);
   }, []);
 

--- a/components/layout/ApiKeyBanner.tsx
+++ b/components/layout/ApiKeyBanner.tsx
@@ -8,6 +8,7 @@ export function ApiKeyBanner() {
 
   const [hasMounted, setHasMounted] = useState(false);
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- canonical SSR-safe mount flag
     setHasMounted(true);
   }, []);
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,9 @@ import nextConfig from "eslint-config-next";
 const eslintConfig = [
   ...nextConfig,
   {
-    ignores: [".artifacts/**"],
+    // e2e/** is excluded while the Playwright suite is being rewritten —
+    // see docs/focus-mode-todo.md §4. Re-include once the suite is functional.
+    ignores: [".artifacts/**", "e2e/**"],
   },
 ];
 

--- a/tests/unit/lib/api/blockAction.test.ts
+++ b/tests/unit/lib/api/blockAction.test.ts
@@ -178,7 +178,9 @@ describe("fetchBlockAction", () => {
       await fetchBlockAction(
         action,
         "passage body",
-        action === "ask" || action === "rewrite" ? "prompt" : undefined,
+        // None of the iterated actions take a prompt; ask/rewrite are
+        // covered by their own dedicated tests.
+        undefined,
         action === "translate" ? "Spanish" : undefined,
         baseSettings,
       );

--- a/tests/unit/lib/export/download.test.ts
+++ b/tests/unit/lib/export/download.test.ts
@@ -13,8 +13,10 @@ describe("downloadMarkdown", () => {
     revokeObjectURLMock = vi.fn();
     clickSpy = vi.fn();
 
-    globalThis.URL.createObjectURL = createObjectURLMock;
-    globalThis.URL.revokeObjectURL = revokeObjectURLMock;
+    globalThis.URL.createObjectURL =
+      createObjectURLMock as unknown as typeof URL.createObjectURL;
+    globalThis.URL.revokeObjectURL =
+      revokeObjectURLMock as unknown as typeof URL.revokeObjectURL;
 
     appendChildSpy = vi.spyOn(document.body, "appendChild").mockImplementation(
       (node) => node,

--- a/tests/unit/lib/export/openInObsidian.test.ts
+++ b/tests/unit/lib/export/openInObsidian.test.ts
@@ -17,7 +17,7 @@ describe("openInObsidian", () => {
 
   const getTriggeredUri = (): string => {
     const anchorCall = createElementSpy.mock.results.find(
-      (r) => (r.value as HTMLElement).tagName === "A",
+      (r: { value: unknown }) => (r.value as HTMLElement).tagName === "A",
     );
     return (anchorCall?.value as HTMLAnchorElement).href;
   };

--- a/tests/unit/lib/state/focus.test.ts
+++ b/tests/unit/lib/state/focus.test.ts
@@ -31,6 +31,7 @@ const makeBaseState = (): AppState =>
     isAwaitingResponse: false,
     error: null,
     focus: null,
+    composerPrompt: '',
   }) as AppState;
 
 beforeEach(() => {

--- a/tests/unit/lib/state/settings.test.ts
+++ b/tests/unit/lib/state/settings.test.ts
@@ -57,6 +57,7 @@ describe("Settings State Functions", () => {
 
     it("should preserve other settings", () => {
       const settings: Settings = {
+        ...DEFAULT_SETTINGS,
         model: "gpt-5.4-mini",
         reasoningEffort: "high",
         webSearchEnabled: true,
@@ -108,6 +109,7 @@ describe("Settings State Functions", () => {
 
     it("should preserve other settings", () => {
       const settings: Settings = {
+        ...DEFAULT_SETTINGS,
         model: "gpt-5.4",
         reasoningEffort: "none",
         webSearchEnabled: true,
@@ -147,6 +149,7 @@ describe("Settings State Functions", () => {
 
     it("should preserve other settings", () => {
       const settings: Settings = {
+        ...DEFAULT_SETTINGS,
         model: "gpt-5.4",
         reasoningEffort: "high",
         webSearchEnabled: false,


### PR DESCRIPTION
## Summary
- Adds three quality gates to the CI pipeline so type errors and lint failures stop showing up only in local dev:
  - **lint** — \`npm run lint\`
  - **typecheck** — \`tsc --noEmit\`
  - **build** — \`npm run build\` as its own job (was only running inside e2e before)
- **Pauses the E2E workflow.** Trigger changed from \`push\` / \`pull_request\` to \`workflow_dispatch\` only. The Playwright suite is being rewritten for the focus-mode refactor (see \`docs/focus-mode-todo.md\` §4). Re-enable once functional. Manual runs via the Actions tab still work.

## Pre-existing failures cleared in scope

Adopting the new gates required fixing things they immediately surfaced. All scoped to test/config files:

- **\`react-hooks/set-state-in-effect\` (lint)** — flagged the two canonical \`useEffect(() => setHasMounted(true), [])\` SSR-hydration mount flags in \`app/landing-content.tsx\` and \`components/layout/ApiKeyBanner.tsx\`. Pattern is correct; added scoped \`eslint-disable-next-line\` with a one-line justification.
- **\`e2e/**\` added to eslint ignores** — has a rules-of-hooks violation in shelved code. Not worth fixing what's about to be rewritten.
- **Test-fixture typecheck drift** — several test fixtures missed fields that have been added to \`Settings\` / \`AppState\` since they were written. Filled in via \`...DEFAULT_SETTINGS\` spreads or explicit fields.
- **\`download.test.ts\` mock typing** — \`vi.fn()\` assignments to \`URL.createObjectURL\` / \`URL.revokeObjectURL\` needed \`as unknown as typeof URL.X\` to satisfy strict types.
- **\`blockAction.test.ts\`** — had dead branches checking for \`action === 'ask' || action === 'rewrite'\` inside a loop over a literal type that excluded both. Pruned.

## Test plan
- [x] \`npm run lint\` clean (0 errors, 1 pre-existing warning unrelated)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — 476/476 passing
- [x] \`npm run build\` clean
- [ ] CI on this PR should report all 4 jobs (lint / typecheck / build / test) passing
- [ ] After merge: enable \"Require status checks to pass before merging\" in branch protection settings, with the four jobs as required checks

## Out of scope
- Adding \`npm audit\` as a CI gate (separate PR — needs a triage of current advisories first)
- Bundle-size monitoring
- Fixing the e2e suite (tracked in \`docs/focus-mode-todo.md\` §4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)