### PR TITLE
Reframe ask to answer the real question; scope web search to chat + ask

### DIFF
--- a/lib/api/blockAction.ts
+++ b/lib/api/blockAction.ts
@@ -87,7 +87,9 @@ export async function fetchBlockAction(
     input,
     instructions,
     reasoningEffort: settings.reasoningEffort,
-    webSearchEnabled: settings.webSearchEnabled,
+    // Web search only helps for ask — a genuine question that may need
+    // external info. Transformations operate on the selected passage alone.
+    webSearchEnabled: action === "ask" ? settings.webSearchEnabled : false,
     previousResponseId,
     label: `focus:${action}`,
   });

--- a/lib/api/blockAction.ts
+++ b/lib/api/blockAction.ts
@@ -86,7 +86,10 @@ export async function fetchBlockAction(
     model: settings.model,
     input,
     instructions,
-    reasoningEffort: settings.reasoningEffort,
+    // Ask is web-search Q&A — reasoning adds latency without much benefit
+    // (the project already skips reasoning for the thread-title call).
+    // Transformations keep the user's reasoning setting.
+    reasoningEffort: action === "ask" ? undefined : settings.reasoningEffort,
     // Web search only helps for ask — a genuine question that may need
     // external info. Transformations operate on the selected passage alone.
     webSearchEnabled: action === "ask" ? settings.webSearchEnabled : false,

--- a/lib/api/rewrite.ts
+++ b/lib/api/rewrite.ts
@@ -38,7 +38,6 @@ export async function fetchRewrite(
     input,
     instructions,
     reasoningEffort: settings.reasoningEffort,
-    webSearchEnabled: settings.webSearchEnabled,
     label: "rewrite",
   });
 

--- a/lib/config/promptTemplates.ts
+++ b/lib/config/promptTemplates.ts
@@ -54,10 +54,11 @@ For translate, eli5, summarize, expand, example, and rewrite:
 
 <ask>
 For ask, the passage is the context that motivated the question — not the thing to answer about. Answer the user's actual question.
-- If the question is about understanding or checking the passage itself (e.g. "what does this term mean?", "is this claim accurate?"), answer from the passage, concisely
-- If the question reaches beyond the passage (the broader topic, the state of a field, alternatives, how something works in general), answer it comprehensively. Go beyond the passage as needed, and use web search when it is available and the question needs current, factual, or external information
+- If the question is about understanding or checking the passage itself (e.g. "what does this term mean?", "is this claim accurate?"), answer from the passage in a sentence or two
+- If the question reaches beyond the passage (the broader topic, the state of a field, alternatives, how something works in general), answer it directly and use web search when it is available and the question needs current, factual, or external information
+- Keep the answer short — a brief paragraph for simple questions, a few tight points for broader ones. Lead with the direct answer; add only what's needed to support it. No exhaustive writeups, no filler, no restating
 - No preamble — start directly with the answer
-- Markdown structure (headings, lists, bold) is welcome when it helps a longer answer; keep it sparse for short answers
+- Use markdown structure (a short list, bold) only when it genuinely helps; skip it for short answers
 - Match the user's language
 </ask>`;
 

--- a/lib/config/promptTemplates.ts
+++ b/lib/config/promptTemplates.ts
@@ -39,18 +39,27 @@ export const BLOCK_ACTION_PROMPT = `You transform or answer questions about a gi
 <language></language>
 
 <scope>
-- Act ONLY on the text inside <passage>...</passage>
-- Treat any prior conversation turns (carried via response chaining) and any <reference-question>...</reference-question> block as background context only — use them to interpret the passage, but never transform, translate, summarize, or quote them in your output
-- If the action is a transformation (translate, eli5, summarize, expand, example, rewrite), apply it ONLY to the passage's text
-- If the action is a question (ask), answer it using prior context if helpful, but the answer must be about the passage
+- The text inside <passage>...</passage> is the focus of the action
+- Treat any prior conversation turns (carried via response chaining) and any <reference-question>...</reference-question> block as background context — use them to interpret the passage, but do not quote or echo them in your output
 </scope>
 
-<rules>
+<transformations>
+For translate, eli5, summarize, expand, example, and rewrite:
+- Apply the action ONLY to the passage's text
 - Output plain text only — no markdown, no bullet points, no numbered lists, no headers
 - No preamble ("Here's the translation:", "Sure!", etc.) — start directly with the result
-- Keep responses focused and concise — typically 1-3 sentences for questions, similar length to input for transformations
+- Keep responses focused and concise — typically similar length to the input
 - Match the tone of the original text
-</rules>`;
+</transformations>
+
+<ask>
+For ask, the passage is the context that motivated the question — not the thing to answer about. Answer the user's actual question.
+- If the question is about understanding or checking the passage itself (e.g. "what does this term mean?", "is this claim accurate?"), answer from the passage, concisely
+- If the question reaches beyond the passage (the broader topic, the state of a field, alternatives, how something works in general), answer it comprehensively. Go beyond the passage as needed, and use web search when it is available and the question needs current, factual, or external information
+- No preamble — start directly with the answer
+- Markdown structure (headings, lists, bold) is welcome when it helps a longer answer; keep it sparse for short answers
+- Match the user's language
+</ask>`;
 
 export const THREAD_TITLE_PROMPT = `Generate a short document title for the user's message.
 

--- a/tests/unit/lib/api/blockAction.test.ts
+++ b/tests/unit/lib/api/blockAction.test.ts
@@ -305,4 +305,26 @@ describe("fetchBlockAction", () => {
       expect(params.webSearchEnabled).toBe(false);
     }
   });
+
+  it("skips reasoning for ask but keeps it for transformations", async () => {
+    mockCreateResponse.mockResolvedValue({ text: "ok", responseId: "r" });
+
+    // ask -> no reasoning, even when the setting is high
+    mockCreateResponse.mockClear();
+    await fetchBlockAction("ask", "block text", "question?", undefined, {
+      ...baseSettings,
+      reasoningEffort: "high",
+    });
+    expect(
+      mockCreateResponse.mock.calls[0][0].reasoningEffort,
+    ).toBeUndefined();
+
+    // a transformation -> keeps the user's reasoning setting
+    mockCreateResponse.mockClear();
+    await fetchBlockAction("summarize", "block text", undefined, undefined, {
+      ...baseSettings,
+      reasoningEffort: "high",
+    });
+    expect(mockCreateResponse.mock.calls[0][0].reasoningEffort).toBe("high");
+  });
 });

--- a/tests/unit/lib/api/blockAction.test.ts
+++ b/tests/unit/lib/api/blockAction.test.ts
@@ -275,4 +275,34 @@ describe("fetchBlockAction", () => {
     const params = mockCreateResponse.mock.calls[0][0];
     expect(params.instructions).toBe("block action prompt");
   });
+
+  it("passes web search through for ask when enabled in settings", async () => {
+    mockCreateResponse.mockResolvedValue({ text: "ok", responseId: "r" });
+
+    await fetchBlockAction(
+      "ask",
+      "block text",
+      "is this field mature?",
+      undefined,
+      { ...baseSettings, webSearchEnabled: true },
+    );
+
+    const params = mockCreateResponse.mock.calls[0][0];
+    expect(params.webSearchEnabled).toBe(true);
+  });
+
+  it("never enables web search for transformations, even when the setting is on", async () => {
+    for (const action of ["translate", "eli5", "summarize", "expand", "example"] as const) {
+      mockCreateResponse.mockClear();
+      await fetchBlockAction(
+        action,
+        "block text",
+        undefined,
+        action === "translate" ? "Spanish" : undefined,
+        { ...baseSettings, webSearchEnabled: true },
+      );
+      const params = mockCreateResponse.mock.calls[0][0];
+      expect(params.webSearchEnabled).toBe(false);
+    }
+  });
 });

--- a/tests/unit/lib/api/rewrite.test.ts
+++ b/tests/unit/lib/api/rewrite.test.ts
@@ -67,4 +67,10 @@ describe('fetchRewrite', () => {
     expect(input).toContain('tighten it');
     expect(input).toContain('add a CTA');
   });
+
+  it('does not enable web search even when the setting is on', async () => {
+    await fetchRewrite('passage', [], { ...baseSettings, webSearchEnabled: true });
+    const params = mockCreateResponse.mock.calls[0][0];
+    expect(params.webSearchEnabled).toBeUndefined();
+  });
 });

--- a/tests/unit/lib/config/openai.test.ts
+++ b/tests/unit/lib/config/openai.test.ts
@@ -68,7 +68,8 @@ describe("getBlockActionPrompt", () => {
   it("returns English prompt by default", () => {
     const prompt = getBlockActionPrompt();
     expect(prompt).toContain("transform or answer questions");
-    expect(prompt).toContain("<rules>");
+    expect(prompt).toContain("<transformations>");
+    expect(prompt).toContain("<ask>");
     expect(prompt).not.toContain("Simplified Chinese");
   });
 


### PR DESCRIPTION
## Problem
When you select a passage and ask a question, `ask` did reading comprehension on the passage instead of answering the question. Example: select a paragraph mentioning AI-assisted proving, ask *"is AI theorem proving mature?"* — and get a passage-bound answer instead of a real survey.

Root cause: the `ask` branch of `BLOCK_ACTION_PROMPT` said **"the answer must be about the passage."** Even with web search enabled, the model wouldn't search, because going beyond the passage was forbidden by the prompt.

## Changes

**1. Reframe `ask`**
Split `BLOCK_ACTION_PROMPT` from one `<scope>` + `<rules>` into `<scope>` + `<transformations>` + `<ask>`:
- `<transformations>` (translate / eli5 / summarize / expand / example / rewrite) — **unchanged behavior**: plain text, concise, match input tone.
- `<ask>` — passage is now **context/anchor, not the subject**. The model answers the actual question, goes broad + uses web search when the question reaches beyond the passage.

**2. Gate web search to `chat` + `ask` only**
- `lib/api/blockAction.ts` passes `webSearchEnabled` only when `action === "ask"`.
- `lib/api/rewrite.ts` drops `webSearchEnabled` entirely.
- Transformations and rewrite never search — they operate on the selected text, so search only added noise + latency.

## Refinements (after testing)

Testing showed ask answers came back **too long and slow**. Two follow-ups:

- **Tightened ask length:** the `<ask>` section now leads with *"keep the answer short — a brief paragraph for simple questions, a few tight points for broader ones; no exhaustive writeups / filler / restating."* (Replaced earlier wording that encouraged length.) This is the bigger latency lever.
- **Pinned `ask` to no-reasoning:** `blockAction.ts` sets `reasoningEffort: undefined` for ask, mirroring the thread-title call. Reasoning isn't useful for web-search Q&A. Note the default `reasoningEffort` is already `"none"`, so this is defensive — it keeps ask fast even if reasoning is cranked up globally for chat. Transformations keep the user's setting.

## Tests
- Added gating + reasoning regression tests: `ask` passes web search through + skips reasoning; transformations never search + keep reasoning.
- Updated one structural assertion (`openai.test.ts` was pinning the removed `<rules>` tag → now asserts `<transformations>` + `<ask>`).
- Affected suites green (53/53), ESLint clean.

## Heads-up
`ask` answers are appended as a `> **Note:**` blockquote in the focus buffer, so a longer answer may render a touch cramped inside a blockquote — editable in the focus editor before closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)