### PR TITLE
Fix trailing ** left outside the focus editor when selecting bold text

### DIFF
--- a/lib/selection/domToSource.ts
+++ b/lib/selection/domToSource.ts
@@ -66,6 +66,15 @@ function endpointToOffset(node: Node, offset: number, kind: Endpoint): number | 
       if (kind === 'start' && offset === 0) {
         return expandLeftward(parent, base);
       }
+      // Mirror case: when a selection ends at the last offset of a text
+      // node, the browser snaps it before any trailing markdown marker
+      // (the closing `**`, `_`, `` ` `` of emphasis/code). Without this,
+      // the trailing marker is left outside the editor's buffer (e.g. a
+      // dangling `**`). Walk up while we're the rightmost child and pick
+      // the largest enclosing data-md-end so the buffer includes it.
+      if (kind === 'end' && offset === text.data.length) {
+        return expandRightward(parent, base + clamped);
+      }
       return base + clamped;
     }
 
@@ -89,6 +98,18 @@ function expandLeftward(textSpan: Element, currentStart: number): number {
     const parent = el.parentElement;
     const start = readStart(parent);
     if (start !== null && start < candidate) candidate = start;
+    el = parent;
+  }
+  return candidate;
+}
+
+function expandRightward(textSpan: Element, currentEnd: number): number {
+  let candidate = currentEnd;
+  let el: Element = textSpan;
+  while (el.parentElement && el.parentElement.lastChild === el) {
+    const parent = el.parentElement;
+    const end = readEnd(parent);
+    if (end !== null && end > candidate) candidate = end;
     el = parent;
   }
   return candidate;

--- a/tests/unit/lib/selection/domToSource.test.tsx
+++ b/tests/unit/lib/selection/domToSource.test.tsx
@@ -165,4 +165,43 @@ describe('domToSource', () => {
       expect(result!.end).toBe(1);
     });
   });
+
+  describe('inline formatting markers at selection boundaries', () => {
+    it('includes the closing ** when a selection ends at the end of a bold run at the paragraph end', () => {
+      const source = 'Some text **bold end**';
+      const container = renderMessage(source);
+      const { node } = findTextNode(container, 'bold end');
+      // select the whole bold run, ending at the run's last offset
+      const range = makeRange(node, 0, node, node.data.length);
+      const result = domToSource(range);
+      expect(result).not.toBeNull();
+      const markerStart = source.indexOf('**bold end**');
+      expect(result!.start).toBe(markerStart); // opening ** included
+      expect(result!.end).toBe(markerStart + '**bold end**'.length); // closing ** included
+    });
+
+    it('includes the closing ** when the bold run is followed by more text', () => {
+      const source = 'Prefix **bold** suffix';
+      const container = renderMessage(source);
+      const { node } = findTextNode(container, 'bold');
+      const range = makeRange(node, 0, node, node.data.length);
+      const result = domToSource(range);
+      expect(result).not.toBeNull();
+      const markerStart = source.indexOf('**bold**');
+      expect(result!.start).toBe(markerStart);
+      expect(result!.end).toBe(markerStart + '**bold**'.length);
+    });
+
+    it('does not include a trailing marker when the selection stops mid-run', () => {
+      const source = 'Prefix **bold** suffix';
+      const container = renderMessage(source);
+      const { node } = findTextNode(container, 'bold');
+      // select only the first two chars of "bold" — ends before the run end,
+      // so no expansion should happen on the end side.
+      const range = makeRange(node, 0, node, 2);
+      const result = domToSource(range);
+      expect(result).not.toBeNull();
+      expect(result!.end).toBe(source.indexOf('bold') + 2);
+    });
+  });
 });


### PR DESCRIPTION
## Problem
When selecting a passage that ends at the boundary of a bold/emphasis run, the focus editor's buffer was missing the **closing `**`** — it was left dangling outside the editor in the rendered message (the reported "two asterisks left outside the editor").

## Root cause
`domToSource` (maps a DOM selection back to source-markdown offsets) had `expandLeftward` — which grabs **leading** markers (opening `**`, `#`, `-`) when a selection *starts* at a run boundary — but **no end-side equivalent**. So when a selection *ended* at the last offset of a bold text node, the browser snapped the endpoint *before* the closing `**`, and the mapping landed just before it. The closing marker was sliced out of the buffer and left in the message.

## Fix
Added `expandRightward` in `lib/selection/domToSource.ts` — a line-for-line mirror of `expandLeftward` (walks up while the text span is the rightmost child, takes the largest enclosing `data-md-end`). Fires **only** when a selection ends at a text node's last offset, so the trailing `**`/`_`/`` ` `` is included exactly when it belongs to the selected text.

**Production change: 21 lines in one file** (`domToSource.ts`); +39 lines of tests.

## Verification
Regression tests that prove the fix (not decorative):
- **Without the fix:** the two "closing `**`" tests **fail** (bug reproduced)
- **With the fix:** all pass
- A "selection stops mid-run → no marker included" test passes in **both** cases — guards against the fix over-expanding
- Full suite: **482/482 passing**, ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)